### PR TITLE
Add guide: Semantic Search over Markdown Docs

### DIFF
--- a/guides/semantic_search_over_markdown/sample_docs/api_reference.md
+++ b/guides/semantic_search_over_markdown/sample_docs/api_reference.md
@@ -1,0 +1,17 @@
+# API Reference
+
+This API allows you to interact with the Markdown Docs Demo system — upload files, search them using natural language, and manage your document collections.
+
+---
+
+## 📤 POST /upload
+
+Upload a new markdown document for semantic indexing.
+
+**Request Body:**
+
+```json
+{
+  "filename": "example.md",
+  "content": "base64_encoded_content"
+}

--- a/guides/semantic_search_over_markdown/sample_docs/intro.md
+++ b/guides/semantic_search_over_markdown/sample_docs/intro.md
@@ -1,0 +1,7 @@
+# Introduction
+
+Welcome to the Markdown Docs Demo! This project showcases how you can use ZeroEntropy to index and search over plain-text documentation.
+
+These markdown files simulate typical developer docs — from getting started instructions to API references. You can use this setup as a starting point to build internal search for wikis, blogs, or changelogs.
+
+Let's get started!

--- a/guides/semantic_search_over_markdown/sample_docs/tutorial.md
+++ b/guides/semantic_search_over_markdown/sample_docs/tutorial.md
@@ -1,0 +1,10 @@
+# Tutorial
+
+This tutorial walks you through setting up the Markdown Docs Demo environment.
+
+## Step 1: Clone the repository
+
+```bash
+git clone https://github.com/zeroentropy-ai/zcookbook.git
+cd markdown-docs-demo
+```

--- a/guides/semantic_search_over_markdown/semantic_search_over_markdown.ipynb
+++ b/guides/semantic_search_over_markdown/semantic_search_over_markdown.ipynb
@@ -1,0 +1,362 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Semantic Search Over Markdown Docs with ZeroEntropy\n",
+    "\n",
+    "In this guide, we’ll build a simple semantic search engine over Markdown documentation files using ZeroEntropy. This is helpful if you want to query large internal wikis, blog posts, or dev docs.\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### Pre-requisites\n",
+    "- Python 3.8+\n",
+    "- `zeroentropy` client (`pip install zeroentropy`)\n",
+    "- A ZeroEntropy API key ([Get yours here](https://dashboard.zeroentropy.dev))\n",
+    "- A .env file with the following: \n",
+    "\n",
+    "```bash\n",
+    "ZEROENTROPY_API_KEY=your_api_key_here\n",
+    "```\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### What You’ll Learn\n",
+    "- How to use ZeroEntropy to semantically index markdown files\n",
+    "- How to query your docs using semantic search (top documents + top snippets)\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### Directory Structure\n",
+    "\n",
+    "This guide expects a directory like this:\n",
+    "\n",
+    "```bash\n",
+    "zcookbook/\n",
+    "├── guides/\n",
+    "│   ├── search_over_many_pdfs.ipynb\n",
+    "│   └── semantic_search_over_markdown/\n",
+    "│       ├── semantic_search_over_markdown.ipynb\n",
+    "│       └── sample_docs/\n",
+    "│           ├── intro.md\n",
+    "│           ├── tutorial.md\n",
+    "│           └── api_reference.md\n",
+    "├── LICENSE\n",
+    "└── README.md\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setting up your ZeroEntropy Client\n",
+    "\n",
+    "First, install dependencies:\n",
+    "\n",
+    "```bash\n",
+    "!pip install zeroentropy python-dotenv\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now load your API key and initialize the client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from zeroentropy import ZeroEntropy\n",
+    "from dotenv import load_dotenv\n",
+    "import os\n",
+    "\n",
+    "load_dotenv(dotenv_path=\"../../.env\")\n",
+    "\n",
+    "api_key = os.getenv(\"ZEROENTROPY_API_KEY\")\n",
+    "if not api_key:\n",
+    "    raise ValueError(\"API Key not found. Make sure your .env file has ZEROENTROPY_API_KEY.\")\n",
+    "\n",
+    "zclient = ZeroEntropy(api_key=api_key)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Creating and Uploading the Markdown Docs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "CollectionAddResponse(message='Success!')"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "collection_name = \"md_docs_demo_vn\"\n",
+    "zclient.collections.add(collection_name=collection_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now define a function to upload .md files as base64 content:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import base64\n",
+    "\n",
+    "def upload_md_file(filepath, collection_name):\n",
+    "    with open(filepath, 'r', encoding='utf-8') as f:\n",
+    "        text = f.read()\n",
+    "        # b64 = base64.b64encode(f.read()).decode('utf-8')\n",
+    "\n",
+    "    file_ext = os.path.splitext(filepath)[1]\n",
+    "\n",
+    "    if file_ext == \".md\":\n",
+    "        content = {\"type\": \"text\", \"text\": text}\n",
+    "    else:\n",
+    "        raise ValueError(\"Unsupported file type\")\n",
+    "\n",
+    "    response = zclient.documents.add(\n",
+    "        collection_name=collection_name,\n",
+    "        path=filepath,\n",
+    "        content=content\n",
+    "    )\n",
+    "    return response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let’s upload all .md files in our sample folder:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DocumentAddResponse(message='Success!')\n",
+      "DocumentAddResponse(message='Success!')\n",
+      "DocumentAddResponse(message='Success!')\n"
+     ]
+    }
+   ],
+   "source": [
+    "folder_path = \"./sample_docs\"\n",
+    "\n",
+    "for filename in os.listdir(folder_path):\n",
+    "    if filename.endswith(\".md\"):\n",
+    "        filepath = os.path.join(folder_path, filename)\n",
+    "        print(upload_md_file(filepath, collection_name))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Confirming Your Documents\n",
+    "\n",
+    "Once uploaded, you can list all documents in your collection like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['./sample_docs\\\\api_reference.md', './sample_docs\\\\intro.md', './sample_docs\\\\tutorial.md']\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = zclient.documents.get_info_list(collection_name=collection_name)\n",
+    "print([doc.path for doc in response.documents])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Querying with ZeroEntropy\n",
+    "We’ll now use semantic search to retrieve the most relevant markdown documents and snippets for a natural language query.\n",
+    "\n",
+    "### Top Document Matches"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Score: 1.6567331566640742\n",
+      "Path: ./sample_docs\\api_reference.md\n",
+      "\n",
+      "Score: 1.444334998181506\n",
+      "Path: ./sample_docs\\intro.md\n",
+      "\n",
+      "Score: 1.2319368396989376\n",
+      "Path: ./sample_docs\\tutorial.md\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = \"How to integrate with our API?\"\n",
+    "response = zclient.queries.top_documents(\n",
+    "    collection_name=collection_name,\n",
+    "    query=query,\n",
+    "    k=3\n",
+    ")\n",
+    "\n",
+    "for r in response.results:\n",
+    "    print(f\"\\nScore: {r.score}\\nPath: {r.path}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Top Snippet Matches"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "📎 Snippet:\n",
+      "# Introduction\n",
+      "\n",
+      "Welcome to the Markdown Docs Demo! This project showcases how you can use ZeroEntropy to index and search over plain-text documentation.\n",
+      "\n",
+      "These markdown files simulate typical developer docs — from getting started instructions to API references. You can use this setup as a starting point to build internal search for wikis, blogs, or changelogs.\n",
+      "\n",
+      "Let's get started!\n",
+      "\n",
+      "📁 Path: ./sample_docs\\intro.md\n",
+      "🔢 Score: 0.24\n",
+      "\n",
+      "📎 Snippet:\n",
+      "# API Reference\n",
+      "\n",
+      "This API allows you to interact with the Markdown Docs Demo system — upload files, search them using natural language, and manage your document collections.\n",
+      "\n",
+      "---\n",
+      "\n",
+      "## 📤 POST /upload\n",
+      "\n",
+      "Upload a new markdown document for semantic indexing.\n",
+      "\n",
+      "**Request Body:**\n",
+      "\n",
+      "```json\n",
+      "{\n",
+      "  \"filename\": \"example.md\",\n",
+      "  \"content\": \"base64_encoded_content\"\n",
+      "}\n",
+      "\n",
+      "📁 Path: ./sample_docs\\api_reference.md\n",
+      "🔢 Score: 0.22\n",
+      "\n",
+      "📎 Snippet:\n",
+      "# Tutorial\n",
+      "\n",
+      "This tutorial walks you through setting up the Markdown Docs Demo environment.\n",
+      "\n",
+      "## Step 1: Clone the repository\n",
+      "\n",
+      "```bash\n",
+      "git clone https://github.com/zeroentropy-ai/zcookbook.git\n",
+      "cd markdown-docs-demo\n",
+      "```\n",
+      "📁 Path: ./sample_docs\\tutorial.md\n",
+      "🔢 Score: 0.21\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = zclient.queries.top_snippets(\n",
+    "        collection_name=collection_name,\n",
+    "        query=query,\n",
+    "        k=3\n",
+    "    )\n",
+    "\n",
+    "for r in response.results:\n",
+    "    print(f\"\\n📎 Snippet:\\n{r.content}\\n📁 Path: {r.path}\\n🔢 Score: {r.score:.2f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### ✅ That's It!\n",
+    "\n",
+    "You’ve now built a working semantic search engine over markdown files using ZeroEntropy — great for indexing changelogs, guides, and internal dev docs."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR adds a cookbook guide demonstrating how to use ZeroEntropy to index and search Markdown documentation files using natural language.

Includes code to upload markdown files, run `top_documents` and `top_snippets` queries, and sample test prompts. 

Useful for internal wikis, changelogs, and blog search interfaces.
