### PR TITLE
fix: correct getting-started friction in zcookbook quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To start using the cookbook, get your [API key](https://dashboard.zeroentropy.de
 
 ```bash
 git clone https://github.com/zeroentropy-ai/zcookbook.git
-cd zeroentropy-cookbook
+cd zcookbook
 ```
 
 ---

--- a/guides/index_and_query_quickstart/README.md
+++ b/guides/index_and_query_quickstart/README.md
@@ -47,7 +47,7 @@ You can modify the default query string in query.py.
 ## File Structure
 
 ```bash
-   index_and_query/
+   index_and_query_quickstart/
 * data/           place your .csv .txt or .pdf files here
 * index.py        indexes all documents in the data folder
 * query.py        queries the indexed documents

--- a/guides/reranker_quickstart/README.md
+++ b/guides/reranker_quickstart/README.md
@@ -14,7 +14,7 @@ The example shows a complete workflow:
 
 ## Prerequisites
 
-- Python 3.8+
+- Python 3.9+
 - ZeroEntropy API key (set as `ZEROENTROPY_API_KEY` environment variable)
 - HuggingFace CLI installed and logged in. Check [here](https://huggingface.co/settings/tokens) for token creation.
 


### PR DESCRIPTION
##summary
- Fix `cd zeroentropy-cookbook` → `cd zcookbook` in root README getting-started block (the cloned directory is named `zcookbook`, not `zeroentropy-cookbook`)
- Create `guides/index_and_query_quickstart/data/.gitkeep` so the `data/` directory exists; `index.py` calls `os.listdir("./data")` and crashes with `FileNotFoundError` if it isn't present
- Fix folder name in `index_and_query_quickstart/README.md` file-structure diagram: `index_and_query/` → `index_and_query_quickstart/`
- Fix minimum Python version in `reranker_quickstart/README.md`: `3.8+` → `3.9+` to match the `zeroentropy` SDK's own `requires-python = ">=3.9"`

##How to reproduce
1. Follow the root README "Getting Started" section verbatim — the `cd` command fails immediately.
2. `cd guides/index_and_query_quickstart && python index.py` — crashes with `FileNotFoundError: [Errno 2] No such file or directory: './data'`.
3. `reranker_quickstart` README advertises Python 3.8 support, but `pip install zeroentropy` on Python 3.8 fails because the SDK requires 3.9+.

##Test plan
- [ ] Clone a fresh copy of the repo and run `cd zcookbook` — succeeds
- [ ] `cd guides/index_and_query_quickstart && ls data/` — directory exists
- [ ] `python index.py` with no files in `data/` returns "Indexing 0 documents" instead of a `FileNotFoundError`
- [ ] `reranker_quickstart/README.md` now accurately reflects SDK requirements