### PR TITLE
Add Azure zerank-2 AKS cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ As of now, the guides in this cookbook are written in Python, but the same conce
    Learn how to use the ZeroEntropy SDK to create collections, index documents, and search with `top_documents`, `top_snippets`, and `top_pages`.
 10. **[zembed-1 Quickstart](guides/zembed_quickstart)**
     Learn how to use `zclient.models.embed()` directly — covers asymmetric retrieval, flexible dimensions, latency modes, sentence similarity, and clustering.
+11. **[Deploy zerank-2 on Azure AKS](guides/azure_zerank2/azure_zerank2.ipynb)**
+    Learn how to deploy `zerank-2` from Azure Marketplace to an H100-backed AKS cluster and test the local rerank endpoint.
 
 *(More guides coming soon...)*
 

--- a/guides/azure_zerank2/azure_zerank2.ipynb
+++ b/guides/azure_zerank2/azure_zerank2.ipynb
@@ -1,0 +1,466 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deploy zerank-2 on Azure AKS\n",
+    "\n",
+    "This notebook shows how to deploy `zerank-2` from Azure Marketplace to an Azure Kubernetes Service (AKS) cluster with an H100 GPU node. You will create the cluster, install the NVIDIA device plugin, deploy the Marketplace extension, and test the local endpoint through `kubectl port-forward`.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- An Azure subscription with quota for `Standard_NC40ads_H100_v5`\n",
+    "- Azure CLI (`az`) installed and authenticated with `az login`\n",
+    "- `kubectl` installed\n",
+    "- `jq` installed for JSON inspection\n",
+    "- Permission to create AKS clusters and Azure Kubernetes extensions\n",
+    "- A resource group in the subscription, or permission to create one\n",
+    "\n",
+    "## What you will do\n",
+    "\n",
+    "- Create a single-node AKS cluster with one H100 GPU\n",
+    "- Install the NVIDIA Kubernetes device plugin\n",
+    "- Deploy `zerank-2` through the Azure Marketplace extension\n",
+    "- Verify the pod, service, GPU allocation, and health endpoint\n",
+    "- Send a sample rerank request to `/invocations`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Configure deployment values\n",
+    "\n",
+    "Set these values before running the shell cells. The Python cell exports them to the notebook process so `%%bash` cells can read them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "config = {\n",
+    "    \"AZURE_RESOURCE_GROUP\": \"<your-resource-group>\",\n",
+    "    \"AKS_CLUSTER_NAME\": \"<your-cluster-name>\",\n",
+    "    \"AZURE_LOCATION\": \"WestUS3\",\n",
+    "    \"AKS_NODE_SIZE\": \"Standard_NC40ads_H100_v5\",\n",
+    "    \"AKS_NODE_COUNT\": \"1\",\n",
+    "    \"ZERANK_EXTENSION_NAME\": \"<your-extension-name>\",\n",
+    "    \"ZERANK_EXTENSION_TYPE\": \"zeroentropy.extension\",\n",
+    "    \"ZERANK_PLAN_NAME\": \"reranker-monthly-plan\",\n",
+    "    \"ZERANK_PLAN_PRODUCT\": \"zeroentropy-zerank-2\",\n",
+    "    \"ZERANK_PLAN_PUBLISHER\": \"zeroentropy\",\n",
+    "    \"ZERANK_NAMESPACE\": \"zerank-2\",\n",
+    "    \"LOCAL_PORT\": \"8080\",\n",
+    "}\n",
+    "\n",
+    "for key, value in config.items():\n",
+    "    os.environ[key] = value\n",
+    "\n",
+    "missing = [key for key, value in config.items() if value.startswith(\"<\") and value.endswith(\">\")]\n",
+    "if missing:\n",
+    "    print(\"Update these values before running the deployment cells:\")\n",
+    "    for key in missing:\n",
+    "        print(f\"  - {key}\")\n",
+    "else:\n",
+    "    print(\"Configuration loaded.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Create the AKS cluster\n",
+    "\n",
+    "Create a single-node AKS cluster backed by `Standard_NC40ads_H100_v5`. If you already have a suitable cluster, skip this cell and run the `az aks get-credentials` cell below.\n",
+    "\n",
+    "The cluster location must have quota for both total regional vCPUs and `Standard NCadsH100v5 Family vCPUs`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "az aks create \\\n",
+    "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
+    "  --name \"$AKS_CLUSTER_NAME\" \\\n",
+    "  --location \"$AZURE_LOCATION\" \\\n",
+    "  --node-count \"$AKS_NODE_COUNT\" \\\n",
+    "  --node-vm-size \"$AKS_NODE_SIZE\" \\\n",
+    "  --generate-ssh-keys"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Connect `kubectl` to the cluster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "az aks get-credentials \\\n",
+    "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
+    "  --name \"$AKS_CLUSTER_NAME\" \\\n",
+    "  --overwrite-existing\n",
+    "\n",
+    "kubectl get nodes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Install the NVIDIA device plugin\n",
+    "\n",
+    "The device plugin advertises GPU resources to Kubernetes. After installation, wait about one minute for the allocatable GPU count to appear on the node."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Verify that Kubernetes sees the GPU. The kubelet may need a minute to refresh node allocatable resources after the plugin registers. This cell retries until it sees `\"gpu\": \"1\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "for i in {1..12}; do\n",
+    "  gpu_count=$(kubectl get nodes -o json | jq -r '.items[0].status.allocatable[\"nvidia.com/gpu\"] // \"\"')\n",
+    "  if [ \"$gpu_count\" = \"1\" ]; then\n",
+    "    kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: .status.allocatable[\"nvidia.com/gpu\"]}'\n",
+    "    exit 0\n",
+    "  fi\n",
+    "  echo \"Waiting for GPU allocatable resource...\"\n",
+    "  sleep 10\n",
+    "done\n",
+    "\n",
+    "kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: .status.allocatable[\"nvidia.com/gpu\"]}'\n",
+    "exit 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Deploy zerank-2 from Azure Marketplace\n",
+    "\n",
+    "You can deploy through the [zerank-2 Azure Marketplace listing](https://marketplace.microsoft.com/en-us/product/zeroentropy.zeroentropy-zerank-2?tab=Overview) or create the Kubernetes extension from the CLI.\n",
+    "\n",
+    "The command below uses the current Azure Marketplace extension type and plan verified for `zerank-2`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "az k8s-extension create \\\n",
+    "  --name \"$ZERANK_EXTENSION_NAME\" \\\n",
+    "  --cluster-name \"$AKS_CLUSTER_NAME\" \\\n",
+    "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
+    "  --cluster-type managedClusters \\\n",
+    "  --extension-type \"$ZERANK_EXTENSION_TYPE\" \\\n",
+    "  --scope cluster \\\n",
+    "  --release-namespace \"$ZERANK_NAMESPACE\" \\\n",
+    "  --plan-name \"$ZERANK_PLAN_NAME\" \\\n",
+    "  --plan-product \"$ZERANK_PLAN_PRODUCT\" \\\n",
+    "  --plan-publisher \"$ZERANK_PLAN_PUBLISHER\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Verify the deployment\n",
+    "\n",
+    "Wait until the pod is ready. The first startup can take several minutes while the image is pulled and the model loads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "kubectl wait \\\n",
+    "  --for=condition=ready pod \\\n",
+    "  -n \"$ZERANK_NAMESPACE\" \\\n",
+    "  -l app.kubernetes.io/name=zerank-2 \\\n",
+    "  --timeout=900s\n",
+    "\n",
+    "kubectl get pods -n \"$ZERANK_NAMESPACE\" -o wide"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List services in the namespace. The service name includes the extension instance name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "kubectl get svc -n \"$ZERANK_NAMESPACE\" -o wide"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check recent logs if the pod is not ready."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "kubectl logs -n \"$ZERANK_NAMESPACE\" -l app.kubernetes.io/name=zerank-2 --tail=100"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Port-forward the service\n",
+    "\n",
+    "This starts `kubectl port-forward` from the notebook kernel and discovers the service name automatically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import subprocess\n",
+    "import time\n",
+    "\n",
+    "namespace = os.environ[\"ZERANK_NAMESPACE\"]\n",
+    "local_port = os.environ[\"LOCAL_PORT\"]\n",
+    "\n",
+    "service_name = subprocess.check_output(\n",
+    "    [\n",
+    "        \"kubectl\",\n",
+    "        \"get\",\n",
+    "        \"svc\",\n",
+    "        \"-n\",\n",
+    "        namespace,\n",
+    "        \"-l\",\n",
+    "        \"app.kubernetes.io/name=zerank-2\",\n",
+    "        \"-o\",\n",
+    "        \"jsonpath={.items[0].metadata.name}\",\n",
+    "    ],\n",
+    "    text=True,\n",
+    ").strip()\n",
+    "\n",
+    "if \"zerank2_port_forward\" in globals() and zerank2_port_forward.poll() is None:\n",
+    "    zerank2_port_forward.terminate()\n",
+    "    zerank2_port_forward.wait(timeout=10)\n",
+    "\n",
+    "zerank2_port_forward = subprocess.Popen(\n",
+    "    [\n",
+    "        \"kubectl\",\n",
+    "        \"port-forward\",\n",
+    "        \"-n\",\n",
+    "        namespace,\n",
+    "        f\"svc/{service_name}\",\n",
+    "        f\"{local_port}:80\",\n",
+    "    ],\n",
+    "    stdout=subprocess.PIPE,\n",
+    "    stderr=subprocess.STDOUT,\n",
+    "    text=True,\n",
+    ")\n",
+    "\n",
+    "time.sleep(3)\n",
+    "if zerank2_port_forward.poll() is not None:\n",
+    "    output = zerank2_port_forward.stdout.read() if zerank2_port_forward.stdout else \"\"\n",
+    "    raise RuntimeError(f\"port-forward exited early:\\n{output}\")\n",
+    "\n",
+    "print(f\"Forwarding localhost:{local_port} to service/{service_name}:80\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Test the rerank endpoint\n",
+    "\n",
+    "Send a sample request to `/invocations`. The response returns document indexes sorted by relevance score, highest first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "curl -X POST \"http://localhost:${LOCAL_PORT}/invocations\" \\\n",
+    "  -H \"Content-Type: application/json\" \\\n",
+    "  -d '{\n",
+    "    \"query\": \"What is machine learning?\",\n",
+    "    \"documents\": [\n",
+    "      \"Machine learning is a subset of artificial intelligence that enables systems to learn from data.\",\n",
+    "      \"The weather forecast for tomorrow predicts sunny skies.\",\n",
+    "      \"Deep learning uses neural networks with many layers to model complex patterns.\"\n",
+    "    ]\n",
+    "  }'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A successful response should look similar to this:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"results\": [\n",
+    "    {\"index\": 0, \"relevance_score\": 0.9446689335413089},\n",
+    "    {\"index\": 2, \"relevance_score\": 0.31878197585323875},\n",
+    "    {\"index\": 1, \"relevance_score\": 0.05886305589012019}\n",
+    "  ]\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "Add `top_n` to the JSON request body to limit the number of returned results. See the [rerank API reference](https://docs.zeroentropy.dev/api-reference/models/rerank) for more request options."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Check service health\n",
+    "\n",
+    "The health endpoint returns service status, model configuration, and GPU mode."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -euo pipefail\n",
+    "\n",
+    "curl \"http://localhost:${LOCAL_PORT}/health\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Stop the port-forward process when you are done testing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if \"zerank2_port_forward\" in globals() and zerank2_port_forward.poll() is None:\n",
+    "    zerank2_port_forward.terminate()\n",
+    "    zerank2_port_forward.wait(timeout=10)\n",
+    "    print(\"Stopped port-forward.\")\n",
+    "else:\n",
+    "    print(\"No running port-forward process found.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Troubleshooting\n",
+    "\n",
+    "- If AKS creation fails, confirm that `AZURE_LOCATION` has quota for both total regional vCPUs and `Standard NCadsH100v5 Family vCPUs`.\n",
+    "- If GPU allocation shows `null`, rerun the GPU verification cell. If it still shows `null`, inspect the NVIDIA device plugin pod in `kube-system`.\n",
+    "- If the Marketplace extension type fails, list the current ZeroEntropy extension registrations with `az k8s-extension extension-types list --cluster-name \"$AKS_CLUSTER_NAME\" --resource-group \"$AZURE_RESOURCE_GROUP\" --cluster-type managedClusters`.\n",
+    "- If `kubectl port-forward` fails, rerun the service listing cell and confirm the `zerank-2` service exists.\n",
+    "- If `/invocations` fails, confirm the pod is `1/1 Running`, then inspect logs with the log cell above.\n",
+    "\n",
+    "Because GPU-backed AKS clusters are expensive, delete unused test clusters from the Azure portal or with `az aks delete` after you finish."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/guides/azure_zerank2/azure_zerank2.ipynb
+++ b/guides/azure_zerank2/azure_zerank2.ipynb
@@ -32,7 +32,7 @@
    "source": [
     "## 1. Configure deployment values\n",
     "\n",
-    "Set these values before running the shell cells. The Python cell exports them to the notebook process so `%%bash` cells can read them."
+    "Set these values before running the command cells. The Python cell exports them to the notebook process and defines a small `run()` helper for shell commands."
    ]
   },
   {
@@ -42,6 +42,7 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import subprocess\n",
     "\n",
     "config = {\n",
     "    \"AZURE_RESOURCE_GROUP\": \"<your-resource-group>\",\n",
@@ -60,6 +61,13 @@
     "\n",
     "for key, value in config.items():\n",
     "    os.environ[key] = value\n",
+    "\n",
+    "def run(command: str):\n",
+    "    return subprocess.run(\n",
+    "        [\"bash\", \"-e\", \"-u\", \"-o\", \"pipefail\", \"-c\", command],\n",
+    "        check=True,\n",
+    "        text=True,\n",
+    "    )\n",
     "\n",
     "missing = [key for key, value in config.items() if value.startswith(\"<\") and value.endswith(\">\")]\n",
     "if missing:\n",
@@ -87,16 +95,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
+    "run(\"\"\"\\\n",
     "az aks create \\\n",
     "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
     "  --name \"$AKS_CLUSTER_NAME\" \\\n",
     "  --location \"$AZURE_LOCATION\" \\\n",
     "  --node-count \"$AKS_NODE_COUNT\" \\\n",
     "  --node-vm-size \"$AKS_NODE_SIZE\" \\\n",
-    "  --generate-ssh-keys"
+    "  --generate-ssh-keys\n",
+    "\"\"\")"
    ]
   },
   {
@@ -112,15 +119,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
+    "run(\"\"\"\\\n",
     "az aks get-credentials \\\n",
     "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
     "  --name \"$AKS_CLUSTER_NAME\" \\\n",
     "  --overwrite-existing\n",
     "\n",
-    "kubectl get nodes"
+    "kubectl get nodes\n",
+    "\"\"\")"
    ]
   },
   {
@@ -138,10 +144,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
-    "kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml"
+    "run(\"\"\"\\\n",
+    "kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml\n",
+    "\"\"\")"
    ]
   },
   {
@@ -157,9 +162,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
+    "run(\"\"\"\\\n",
     "for i in {1..12}; do\n",
     "  gpu_count=$(kubectl get nodes -o json | jq -r '.items[0].status.allocatable[\"nvidia.com/gpu\"] // \"\"')\n",
     "  if [ \"$gpu_count\" = \"1\" ]; then\n",
@@ -171,7 +174,8 @@
     "done\n",
     "\n",
     "kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: .status.allocatable[\"nvidia.com/gpu\"]}'\n",
-    "exit 1"
+    "exit 1\n",
+    "\"\"\")"
    ]
   },
   {
@@ -191,9 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
+    "run(\"\"\"\\\n",
     "az k8s-extension create \\\n",
     "  --name \"$ZERANK_EXTENSION_NAME\" \\\n",
     "  --cluster-name \"$AKS_CLUSTER_NAME\" \\\n",
@@ -204,7 +206,8 @@
     "  --release-namespace \"$ZERANK_NAMESPACE\" \\\n",
     "  --plan-name \"$ZERANK_PLAN_NAME\" \\\n",
     "  --plan-product \"$ZERANK_PLAN_PRODUCT\" \\\n",
-    "  --plan-publisher \"$ZERANK_PLAN_PUBLISHER\""
+    "  --plan-publisher \"$ZERANK_PLAN_PUBLISHER\"\n",
+    "\"\"\")"
    ]
   },
   {
@@ -222,16 +225,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
+    "run(\"\"\"\\\n",
     "kubectl wait \\\n",
     "  --for=condition=ready pod \\\n",
     "  -n \"$ZERANK_NAMESPACE\" \\\n",
     "  -l app.kubernetes.io/name=zerank-2 \\\n",
     "  --timeout=900s\n",
     "\n",
-    "kubectl get pods -n \"$ZERANK_NAMESPACE\" -o wide"
+    "kubectl get pods -n \"$ZERANK_NAMESPACE\" -o wide\n",
+    "\"\"\")"
    ]
   },
   {
@@ -247,10 +249,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
-    "kubectl get svc -n \"$ZERANK_NAMESPACE\" -o wide"
+    "run(\"\"\"\\\n",
+    "kubectl get svc -n \"$ZERANK_NAMESPACE\" -o wide\n",
+    "\"\"\")"
    ]
   },
   {
@@ -266,10 +267,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
-    "kubectl logs -n \"$ZERANK_NAMESPACE\" -l app.kubernetes.io/name=zerank-2 --tail=100"
+    "run(\"\"\"\\\n",
+    "kubectl logs -n \"$ZERANK_NAMESPACE\" -l app.kubernetes.io/name=zerank-2 --tail=100\n",
+    "\"\"\")"
    ]
   },
   {
@@ -350,9 +350,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
+    "run(\"\"\"\\\n",
     "curl -X POST \"http://localhost:${LOCAL_PORT}/invocations\" \\\n",
     "  -H \"Content-Type: application/json\" \\\n",
     "  -d '{\n",
@@ -362,7 +360,8 @@
     "      \"The weather forecast for tomorrow predicts sunny skies.\",\n",
     "      \"Deep learning uses neural networks with many layers to model complex patterns.\"\n",
     "    ]\n",
-    "  }'"
+    "  }'\n",
+    "\"\"\")"
    ]
   },
   {
@@ -399,10 +398,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%bash\n",
-    "set -euo pipefail\n",
-    "\n",
-    "curl \"http://localhost:${LOCAL_PORT}/health\""
+    "run(\"\"\"\\\n",
+    "curl \"http://localhost:${LOCAL_PORT}/health\"\n",
+    "\"\"\")"
    ]
   },
   {


### PR DESCRIPTION
- Add a cookbook notebook for deploying zerank-2 on an H100-backed Azure AKS cluster.
- Include verified Azure Marketplace extension settings, GPU validation, service discovery, port-forwarding, invocation, and health checks.
- Add the new guide to the cookbook README.