### PR TITLE
Add zembed-1 SageMaker marketplace notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ As of now, the guides in this cookbook are written in Python, but the same conce
    Learn how to use the ZeroEntropy SDK to create collections, index documents, and search with `top_documents`, `top_snippets`, and `top_pages`.
 10. **[zembed-1 Quickstart](guides/zembed_quickstart)**
     Learn how to use `zclient.models.embed()` directly — covers asymmetric retrieval, flexible dimensions, latency modes, sentence similarity, and clustering.
-11. **[Deploy zerank-2 on Azure AKS](guides/azure_zerank2/azure_zerank2.ipynb)**
+11. **[Deploy zembed-1 on AWS SageMaker](guides/sagemaker_usage/zembed-1-SageMaker-model.ipynb)**
+    Learn how to deploy `zembed-1` from AWS Marketplace to SageMaker, run real-time embedding requests, run batch transform jobs, and clean up resources.
+12. **[Deploy zerank-2 on Azure AKS](guides/azure_zerank2/azure_zerank2.ipynb)**
     Learn how to deploy `zerank-2` from Azure Marketplace to an H100-backed AKS cluster and test the local rerank endpoint.
 
 *(More guides coming soon...)*

--- a/guides/sagemaker_usage/zembed-1-SageMaker-model.ipynb
+++ b/guides/sagemaker_usage/zembed-1-SageMaker-model.ipynb
@@ -1,0 +1,674 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Deploy ZeroEntropy's zembed-1 Model Package from AWS Marketplace\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "This notebook's CI test result for us-west-2 is as follows. CI test results in other regions can be found at the end of the notebook.\n",
+    "\n",
+    "![This us-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-2/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**NOTE: If you're not running this notebook on SageMaker Notebooks or SageMaker Studio, define `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, and `SAGEMAKER_EXECUTION_ROLE_ARN` before launching the notebook server.**\n",
+    "\n",
+    "zembed-1 is ZeroEntropy's flagship embedding model for high-accuracy semantic retrieval. It converts queries and documents into vectors for RAG, agents, semantic search, hybrid retrieval, clustering, deduplication, and knowledge-base indexing.\n",
+    "\n",
+    "This sample notebook shows you how to deploy ZeroEntropy zembed-1 from AWS Marketplace using Amazon SageMaker.\n",
+    "\n",
+    "> **Note**: This is a reference notebook. If you are not running in the same AWS Region as the model package ARN shown below, copy the Product ARN for your selected Region from the AWS Marketplace configuration page and replace `model_package_arn`.\n",
+    "\n",
+    "## Pre-requisites:\n",
+    "1. **Note**: This notebook contains elements which render correctly in the Jupyter interface. Open this notebook from an Amazon SageMaker Notebook Instance or Amazon SageMaker Studio.\n",
+    "1. Ensure that the IAM role used has **AmazonSageMakerFullAccess** or equivalent SageMaker permissions.\n",
+    "1. To deploy this ML model successfully, ensure that:\n",
+    "    1. Either your IAM role has these three permissions and you have authority to make AWS Marketplace subscriptions in the AWS account used:\n",
+    "        1. **aws-marketplace:ViewSubscriptions**\n",
+    "        1. **aws-marketplace:Unsubscribe**\n",
+    "        1. **aws-marketplace:Subscribe**\n",
+    "    2. or your AWS account has a subscription to ZeroEntropy zembed-1. If so, skip step: [Subscribe to the model package](#1.-Subscribe-to-the-model-package)\n",
+    "\n",
+    "## Contents:\n",
+    "1. [Subscribe to the model package](#1.-Subscribe-to-the-model-package)\n",
+    "2. [Create an endpoint and perform real-time inference](#2.-Create-an-endpoint-and-perform-real-time-inference)\n",
+    "   1. [Create an endpoint](#A.-Create-an-endpoint)\n",
+    "   2. [Create input payload](#B.-Create-input-payload)\n",
+    "   3. [Perform real-time inference](#C.-Perform-real-time-inference)\n",
+    "   4. [Visualize output](#D.-Visualize-output)\n",
+    "   5. [Delete the endpoint](#E.-Delete-the-endpoint)\n",
+    "3. [Perform batch inference](#3.-Perform-batch-inference)\n",
+    "4. [Clean-up](#4.-Clean-up)\n",
+    "    1. [Delete the model](#A.-Delete-the-model)\n",
+    "    2. [Unsubscribe to the listing (optional)](#B.-Unsubscribe-to-the-listing-(optional))\n",
+    "\n",
+    "## Usage instructions\n",
+    "You can run this notebook one cell at a time by using Shift+Enter.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Subscribe to the model package\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To subscribe to the model package:\n",
+    "1. Open the ZeroEntropy zembed-1 model package listing page in AWS Marketplace.\n",
+    "1. On the AWS Marketplace listing, click on the **Continue to subscribe** button.\n",
+    "1. On the **Subscribe to this software** page, review the EULA, pricing, and support terms, then click **Accept Offer** if you and your organization agree.\n",
+    "1. Click **Continue to configuration**, choose a **Region**, and copy the displayed **Product ARN**. This is the model package ARN that you need when creating a deployable model with Boto3.\n",
+    "1. Paste the Product ARN into the following cell if it differs from the default ARN.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_package_arn = \"arn:aws:sagemaker:us-east-1:148761660947:model-package/zembed-1-v1-0\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Install Required Dependencies\n",
+    "\n",
+    "Before running this notebook, install the required packages:\n",
+    "\n",
+    "```bash\n",
+    "# If using pip\n",
+    "pip install sagemaker boto3 numpy\n",
+    "\n",
+    "# If using uv\n",
+    "uv add sagemaker boto3 numpy\n",
+    "\n",
+    "# If using conda\n",
+    "conda install -c conda-forge sagemaker boto3 numpy\n",
+    "```\n",
+    "\n",
+    "If you're running this in Amazon SageMaker Studio or a SageMaker Notebook Instance, most of these packages are pre-installed. You may only need to upgrade them:\n",
+    "\n",
+    "```bash\n",
+    "pip install --upgrade sagemaker boto3\n",
+    "```\n",
+    "\n",
+    "Or run this cell first:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --upgrade sagemaker boto3 numpy\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure AWS Credentials\n",
+    "\n",
+    "This section works without changes inside SageMaker Studio or a SageMaker Notebook Instance. If you run locally, set AWS credentials and `SAGEMAKER_EXECUTION_ROLE_ARN` before starting Jupyter.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "import boto3\n",
+    "import numpy as np\n",
+    "import sagemaker as sage\n",
+    "from botocore.exceptions import ClientError\n",
+    "from sagemaker import get_execution_role\n",
+    "\n",
+    "boto_session = boto3.Session()\n",
+    "region = boto_session.region_name or os.environ.get(\"AWS_DEFAULT_REGION\", \"us-east-1\")\n",
+    "sagemaker_session = sage.Session(boto_session=boto_session)\n",
+    "sm_client = boto_session.client(\"sagemaker\", region_name=region)\n",
+    "runtime = boto_session.client(\"sagemaker-runtime\", region_name=region)\n",
+    "\n",
+    "try:\n",
+    "    role = get_execution_role()\n",
+    "except Exception:\n",
+    "    role = os.environ.get(\"SAGEMAKER_EXECUTION_ROLE_ARN\")\n",
+    "\n",
+    "if not role:\n",
+    "    raise ValueError(\n",
+    "        \"Could not determine a SageMaker execution role. \"\n",
+    "        \"Run this notebook in SageMaker Studio/Notebook Instance or set SAGEMAKER_EXECUTION_ROLE_ARN.\"\n",
+    "    )\n",
+    "\n",
+    "bucket = sagemaker_session.default_bucket()\n",
+    "print(f\"Region: {region}\")\n",
+    "print(f\"Default bucket: {bucket}\")\n",
+    "print(f\"Execution role: {role}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import time\n",
+    "import uuid\n",
+    "from pathlib import Path\n",
+    "\n",
+    "model_package_region = model_package_arn.split(\":\")[3]\n",
+    "if model_package_region != region:\n",
+    "    print(\n",
+    "        f\"This notebook is running in {region}, but model_package_arn is in {model_package_region}. \"\n",
+    "        \"Use the Product ARN for your selected AWS Marketplace Region or switch your notebook Region.\"\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Create an endpoint and perform real-time inference\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you want to understand how real-time inference with Amazon SageMaker works, see [Documentation](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-hosting.html).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Identifier for the endpoint for your organization. Add a short random suffix to avoid name collisions.\n",
+    "suffix = uuid.uuid4().hex[:8]\n",
+    "model_name = f\"zembed-1-model-{suffix}\"\n",
+    "endpoint_config_name = f\"zembed-1-config-{suffix}\"\n",
+    "endpoint_name = f\"zembed-1-endpoint-{suffix}\"\n",
+    "\n",
+    "content_type = \"application/json\"\n",
+    "accept = \"application/json\"\n",
+    "\n",
+    "real_time_inference_instance_type = (\n",
+    "    \"ml.g6e.xlarge\"  # Recommended for real-time inference, subject to availability in your AWS Region.\n",
+    ")\n",
+    "batch_transform_inference_instance_type = (\n",
+    "    \"ml.g5.2xlarge\"  # Recommended for batch transform, subject to availability in your AWS Region.\n",
+    ")\n",
+    "\n",
+    "# zembed-1 uses CUDA 12-capable SageMaker AMIs for GPU deployment.\n",
+    "real_time_inference_ami_version = \"al2-ami-sagemaker-inference-gpu-2-1\"\n",
+    "batch_transform_ami_version = \"al2-ami-sagemaker-batch-gpu-535\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A. Create an endpoint\n",
+    "\n",
+    "This usually takes 5-10 minutes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a deployable SageMaker model from the AWS Marketplace model package.\n",
+    "sm_client.create_model(\n",
+    "    ModelName=model_name,\n",
+    "    ExecutionRoleArn=role,\n",
+    "    PrimaryContainer={\"ModelPackageName\": model_package_arn},\n",
+    ")\n",
+    "\n",
+    "sm_client.create_endpoint_config(\n",
+    "    EndpointConfigName=endpoint_config_name,\n",
+    "    ProductionVariants=[\n",
+    "        {\n",
+    "            \"VariantName\": \"AllTraffic\",\n",
+    "            \"ModelName\": model_name,\n",
+    "            \"InitialInstanceCount\": 1,\n",
+    "            \"InstanceType\": real_time_inference_instance_type,\n",
+    "            \"InitialVariantWeight\": 1.0,\n",
+    "            \"InferenceAmiVersion\": real_time_inference_ami_version,\n",
+    "        }\n",
+    "    ],\n",
+    ")\n",
+    "\n",
+    "sm_client.create_endpoint(\n",
+    "    EndpointName=endpoint_name,\n",
+    "    EndpointConfigName=endpoint_config_name,\n",
+    ")\n",
+    "\n",
+    "waiter = sm_client.get_waiter(\"endpoint_in_service\")\n",
+    "waiter.wait(EndpointName=endpoint_name)\n",
+    "print(f\"Endpoint is in service: {endpoint_name}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once the endpoint has been created, you can perform real-time embedding requests.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint_name\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### B. Create input payload\n",
+    "\n",
+    "The input to zembed-1 is an `embedding_type` and one or more strings to embed.\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"embedding_type\": \"query\",\n",
+    "  \"input\": [\n",
+    "    \"<string>\"\n",
+    "  ],\n",
+    "  \"dimensions\": 1280\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "Use `\"query\"` for search queries and `\"document\"` for corpus passages. `dimensions` is optional. Supported values are `40`, `80`, `160`, `320`, `640`, `1280`, and `2560`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_payload = {\n",
+    "    \"embedding_type\": \"query\",\n",
+    "    \"input\": [\"what is the first step in making apple jam\"],\n",
+    "    \"dimensions\": 1280,\n",
+    "}\n",
+    "\n",
+    "document_payload = {\n",
+    "    \"embedding_type\": \"document\",\n",
+    "    \"input\": [\n",
+    "        \"apple stocks were down 1%\",\n",
+    "        \"boil apples before adding sugar to make jam\",\n",
+    "        \"freeze apples for a cold dessert\",\n",
+    "        \"one rotten apple ruins the basket\",\n",
+    "        \"the preserve must be left to cool\",\n",
+    "        \"jam to some tunes\",\n",
+    "    ],\n",
+    "    \"dimensions\": 1280,\n",
+    "}\n",
+    "\n",
+    "print(json.dumps(query_payload, indent=2))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### C. Perform real-time inference\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def invoke_zembed(payload):\n",
+    "    response = runtime.invoke_endpoint(\n",
+    "        EndpointName=endpoint_name,\n",
+    "        ContentType=content_type,\n",
+    "        Accept=accept,\n",
+    "        Body=json.dumps(payload).encode(\"utf-8\"),\n",
+    "    )\n",
+    "    result_body = response[\"Body\"].read()\n",
+    "    return json.loads(result_body.decode(\"utf-8\"))\n",
+    "\n",
+    "query_result = invoke_zembed(query_payload)\n",
+    "document_result = invoke_zembed(document_payload)\n",
+    "\n",
+    "query_result\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### D. Visualize output\n",
+    "\n",
+    "zembed-1 returns an object containing `embeddings`, per-input token counts, and usage metadata. The vectors are returned in the same order as the input strings.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_embedding = np.array(query_result[\"embeddings\"][0])\n",
+    "document_embeddings = np.array(document_result[\"embeddings\"])\n",
+    "\n",
+    "print(f\"Query embeddings: {len(query_result['embeddings'])}\")\n",
+    "print(f\"Document embeddings: {len(document_result['embeddings'])}\")\n",
+    "print(f\"Vector dimension: {len(query_embedding)}\")\n",
+    "print(f\"Query token counts: {query_result.get('num_tokens')}\")\n",
+    "print(f\"Document token counts: {document_result.get('num_tokens')}\")\n",
+    "print(f\"Usage: {document_result.get('usage')}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Rank documents by dot-product similarity to the query.\n",
+    "scores = document_embeddings @ query_embedding\n",
+    "ranked = sorted(enumerate(scores), key=lambda item: item[1], reverse=True)\n",
+    "\n",
+    "print(f\"Query: {query_payload['input'][0]}\\n\")\n",
+    "for rank, (idx, score) in enumerate(ranked, start=1):\n",
+    "    print(f\"{rank}. score={score:.4f} | {document_payload['input'][idx]}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### E. Delete the endpoint\n",
+    "\n",
+    "Now that you have successfully performed real-time inference, you can terminate the endpoint to avoid being charged.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sm_client.delete_endpoint(EndpointName=endpoint_name)\n",
+    "\n",
+    "waiter = sm_client.get_waiter(\"endpoint_deleted\")\n",
+    "waiter.wait(EndpointName=endpoint_name)\n",
+    "\n",
+    "sm_client.delete_endpoint_config(EndpointConfigName=endpoint_config_name)\n",
+    "print(f\"Deleted endpoint and endpoint config: {endpoint_name}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also invoke the endpoint with the AWS CLI:\n",
+    "\n",
+    "```bash\n",
+    "aws sagemaker-runtime invoke-endpoint \\\n",
+    "  --endpoint-name <endpoint-name> \\\n",
+    "  --body fileb://input.json \\\n",
+    "  --content-type application/json \\\n",
+    "  --accept application/json \\\n",
+    "  --region <region> \\\n",
+    "  output.json\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Perform batch inference\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this section, you will perform batch inference using multiple JSONL payloads. If you are not familiar with batch transform, see these links:\n",
+    "1. [How it works](https://docs.aws.amazon.com/sagemaker/latest/dg/ex1-batch-transform.html)\n",
+    "2. [How to run a batch transform job](https://docs.aws.amazon.com/sagemaker/latest/dg/how-it-works-batch.html)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If you deleted the real-time endpoint above, the SageMaker model still exists and can be reused for batch transform.\n",
+    "batch_input_filename = \"zembed_batch_input.jsonl\"\n",
+    "batch_records = [\n",
+    "    {\n",
+    "        \"embedding_type\": \"query\",\n",
+    "        \"input\": [\"what is apple jam made from\"],\n",
+    "        \"dimensions\": 1280,\n",
+    "    },\n",
+    "    {\n",
+    "        \"embedding_type\": \"document\",\n",
+    "        \"input\": [\n",
+    "            \"Apple jam is made by cooking apples with sugar until the fruit thickens.\",\n",
+    "            \"A GPU instance can host a SageMaker endpoint for real-time inference.\",\n",
+    "        ],\n",
+    "        \"dimensions\": 1280,\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "with open(batch_input_filename, \"w\", encoding=\"utf-8\") as f:\n",
+    "    for record in batch_records:\n",
+    "        f.write(json.dumps(record) + \"\\n\")\n",
+    "\n",
+    "print(Path(batch_input_filename).read_text())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Upload the batch-transform job input file to S3.\n",
+    "transform_input = sagemaker_session.upload_data(\n",
+    "    batch_input_filename,\n",
+    "    bucket=bucket,\n",
+    "    key_prefix=f\"zembed-1/batch-input/{suffix}\",\n",
+    ")\n",
+    "print(\"Transform input uploaded to \" + transform_input)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transform_job_name = f\"zembed-1-transform-{suffix}\"\n",
+    "transform_output = f\"s3://{bucket}/zembed-1/batch-output/{suffix}/\"\n",
+    "\n",
+    "sm_client.create_transform_job(\n",
+    "    TransformJobName=transform_job_name,\n",
+    "    ModelName=model_name,\n",
+    "    TransformInput={\n",
+    "        \"DataSource\": {\"S3DataSource\": {\"S3DataType\": \"S3Prefix\", \"S3Uri\": transform_input}},\n",
+    "        \"ContentType\": content_type,\n",
+    "        \"SplitType\": \"Line\",\n",
+    "    },\n",
+    "    TransformOutput={\"S3OutputPath\": transform_output, \"Accept\": accept},\n",
+    "    TransformResources={\n",
+    "        \"InstanceType\": batch_transform_inference_instance_type,\n",
+    "        \"InstanceCount\": 1,\n",
+    "        \"TransformAmiVersion\": batch_transform_ami_version,\n",
+    "    },\n",
+    ")\n",
+    "\n",
+    "waiter = sm_client.get_waiter(\"transform_job_completed_or_stopped\")\n",
+    "waiter.wait(TransformJobName=transform_job_name)\n",
+    "print(f\"Transform job completed: {transform_job_name}\")\n",
+    "print(f\"Transform output: {transform_output}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download and inspect the batch output.\n",
+    "s3 = boto_session.client(\"s3\", region_name=region)\n",
+    "output_key = f\"zembed-1/batch-output/{suffix}/{batch_input_filename}.out\"\n",
+    "local_output = \"zembed_batch_output.jsonl.out\"\n",
+    "\n",
+    "s3.download_file(bucket, output_key, local_output)\n",
+    "print(Path(local_output).read_text()[:2000])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Clean-up\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A. Delete the model\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the SageMaker model after both endpoint and batch examples are finished.\n",
+    "try:\n",
+    "    sm_client.delete_model(ModelName=model_name)\n",
+    "    print(f\"Deleted model: {model_name}\")\n",
+    "except ClientError as exc:\n",
+    "    if exc.response[\"Error\"].get(\"Code\") == \"ValidationException\":\n",
+    "        print(f\"Model was already deleted or does not exist: {model_name}\")\n",
+    "    else:\n",
+    "        raise\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### B. Unsubscribe to the listing (optional)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you would like to unsubscribe from the model package, follow these steps. Before you cancel the subscription, ensure that you do not have any [deployable model](https://console.aws.amazon.com/sagemaker/home#/models) created from the model package or using the algorithm. You can find this information by looking at the container name associated with the model.\n",
+    "\n",
+    "**Steps to unsubscribe from the product in AWS Marketplace**:\n",
+    "1. Navigate to the __Machine Learning__ tab on [__Your Software subscriptions page__](https://aws.amazon.com/marketplace/ai/library?productType=ml&ref_=mlmp_gitdemo_indust)\n",
+    "2. Locate the listing that you want to cancel, and then choose __Cancel Subscription__.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notebook CI Test Results\n",
+    "\n",
+    "This notebook was tested in multiple regions. The test results are as follows, except for us-west-2 which is shown at the top of the notebook.\n",
+    "\n",
+    "![This us-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-1/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This us-east-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-east-2/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This us-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/us-west-1/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This ca-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ca-central-1/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This sa-east-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/sa-east-1/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This eu-west-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-1/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This eu-west-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-2/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This eu-west-3 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-west-3/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This eu-central-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-central-1/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This eu-north-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/eu-north-1/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This ap-southeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-1/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This ap-southeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-southeast-2/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This ap-northeast-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-1/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This ap-northeast-2 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-northeast-2/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n",
+    "\n",
+    "![This ap-south-1 badge failed to load. Check your device's internet connectivity, otherwise the service is currently unavailable](https://prod.us-west-2.tcx-beacon.docs.aws.dev/sagemaker-nb/ap-south-1/aws_marketplace|curating_aws_marketplace_listing_and_sample_notebook|ModelPackage|Sample_Notebook_Template|zembed-1-SageMaker-model.ipynb)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "instance_type": "ml.t3.medium",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
- Add a zembed-1-specific SageMaker Marketplace notebook under `guides/sagemaker_usage/`.
- Mirror the existing zerank SageMaker notebook flow: subscribe, configure credentials, create endpoint, invoke real-time inference, run batch transform, and clean up resources.
- Use zembed-specific request and response examples with `embedding_type`, `input`, `dimensions`, embeddings, token counts, and usage metadata.

## Test Plan
- `python3` notebook validation: JSON parse, required zembed fields present, zerank-only strings absent, and Python code cells parse with `ast` after skipping `%pip` magic.

## Notes
- I did not execute the notebook end to end because that would create SageMaker resources.