### PR TITLE
Decode zembed SageMaker embeddings in notebook

### DIFF
--- a/guides/sagemaker_usage/zembed-1-SageMaker-model.ipynb
+++ b/guides/sagemaker_usage/zembed-1-SageMaker-model.ipynb
@@ -176,6 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import base64\n",
     "import json\n",
     "import time\n",
     "import uuid\n",
@@ -376,7 +377,9 @@
    "source": [
     "### D. Visualize output\n",
     "\n",
-    "zembed-1 returns an object containing `embeddings`, per-input token counts, and usage metadata. The vectors are returned in the same order as the input strings.\n"
+    "zembed-1 returns an object containing `embeddings`, per-input token counts, and usage metadata. The vectors are returned in the same order as the input strings.\n",
+    "\n",
+    "Each embedding is a base64-encoded little-endian float16 vector. Decode it before computing similarity, storing it in a vector database, or converting it to another format.\n"
    ]
   },
   {
@@ -385,8 +388,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "query_embedding = np.array(query_result[\"embeddings\"][0])\n",
-    "document_embeddings = np.array(document_result[\"embeddings\"])\n",
+    "def decode_embedding(encoded_embedding: str) -> np.ndarray:\n",
+    "    \"\"\"Decode one base64 float16 embedding returned by zembed-1.\"\"\"\n",
+    "    raw = base64.b64decode(encoded_embedding)\n",
+    "    return np.frombuffer(raw, dtype=\"<f2\").astype(np.float32)\n",
+    "\n",
+    "\n",
+    "def decode_embeddings(result: dict) -> np.ndarray:\n",
+    "    return np.vstack([decode_embedding(item) for item in result[\"embeddings\"]])\n",
+    "\n",
+    "\n",
+    "query_embedding = decode_embedding(query_result[\"embeddings\"][0])\n",
+    "document_embeddings = decode_embeddings(document_result)\n",
     "\n",
     "print(f\"Query embeddings: {len(query_result['embeddings'])}\")\n",
     "print(f\"Document embeddings: {len(document_result['embeddings'])}\")\n",
@@ -557,7 +570,14 @@
     "local_output = \"zembed_batch_output.jsonl.out\"\n",
     "\n",
     "s3.download_file(bucket, output_key, local_output)\n",
-    "print(Path(local_output).read_text()[:2000])\n"
+    "\n",
+    "for line_number, line in enumerate(Path(local_output).read_text().splitlines(), start=1):\n",
+    "    result = json.loads(line)\n",
+    "    decoded = decode_embeddings(result)\n",
+    "    print(\n",
+    "        f\"line={line_number} embeddings={len(result['embeddings'])} \"\n",
+    "        f\"dimension={decoded.shape[1]} token_counts={result.get('num_tokens')}\"\n",
+    "    )\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Update the zembed-1 SageMaker Marketplace notebook to decode base64 float16 embeddings before using NumPy.
- Update the batch-transform inspection example to parse output JSONL and print decoded vector dimensions.

## Test Plan
- `python3` notebook validation: JSON parse, required base64 decoding strings present, and Python code cells parse with `ast` after skipping `%pip` magic.
- Limited SageMaker batch-transform smoke test returned a base64 f16 embedding that decodes to 1280 dimensions.