### PR TITLE
Add Azure zembed-1 cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ As of now, the guides in this cookbook are written in Python, but the same conce
     Learn how to deploy `zembed-1` from AWS Marketplace to SageMaker, run real-time embedding requests, run batch transform jobs, and clean up resources.
 12. **[Deploy zerank-2 on Azure AKS](guides/azure_zerank2/azure_zerank2.ipynb)**
     Learn how to deploy `zerank-2` from Azure Marketplace to an H100-backed AKS cluster and test the local rerank endpoint.
+13. **[Deploy zembed-1 on Azure AKS](guides/azure_zembed1/azure_zembed1.ipynb)**
+    Learn how to deploy `zembed-1` from Azure Marketplace to an H100-backed AKS cluster and test the local embedding endpoint.
 
 *(More guides coming soon...)*
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ As of now, the guides in this cookbook are written in Python, but the same conce
     Learn how to deploy `zembed-1` from AWS Marketplace to SageMaker, run real-time embedding requests, run batch transform jobs, and clean up resources.
 12. **[Deploy zerank-2 on Azure AKS](guides/azure_zerank2/azure_zerank2.ipynb)**
     Learn how to deploy `zerank-2` from Azure Marketplace to an H100-backed AKS cluster and test the local rerank endpoint.
-13. **[Deploy zembed-1 on Azure AKS](guides/azure_zembed1/azure_zembed1.ipynb)**
+13. **[Deploy zembed-1 on Azure AKS](guides/azure_zembed1/README.md)**
     Learn how to deploy `zembed-1` from Azure Marketplace to an H100-backed AKS cluster and test the local embedding endpoint.
 
 *(More guides coming soon...)*

--- a/guides/azure_zembed1/README.md
+++ b/guides/azure_zembed1/README.md
@@ -1,0 +1,482 @@
+# Deploy zembed-1 on Azure AKS
+
+This notebook shows how to deploy `zembed-1` from Azure Marketplace to an Azure Kubernetes Service (AKS) cluster with an H100 GPU node. You will create the cluster, install the NVIDIA device plugin, deploy the Marketplace extension, and test the local embedding endpoint through `kubectl port-forward`.
+
+Executable notebook: [azure_zembed1.ipynb](azure_zembed1.ipynb)
+
+## Prerequisites
+
+- An Azure subscription with quota for `Standard_NC40ads_H100_v5`
+- Azure CLI (`az`) installed and authenticated with `az login`
+- `kubectl` installed
+- `jq` installed for JSON inspection
+- Permission to create AKS clusters and Azure Kubernetes extensions
+- A resource group in the subscription, or permission to create one
+
+## What you will do
+
+- Check the Azure Marketplace terms and H100 quota
+- Create a single-node AKS cluster with one H100 GPU
+- Install the NVIDIA Kubernetes device plugin
+- Deploy `zembed-1` through the Azure Marketplace extension
+- Verify the pod, service, GPU allocation, and health endpoint
+- Send sample embedding requests to `/invocations`
+
+
+## 1. Configure deployment values
+
+Set these values before running the command cells. The Python cell exports them to the notebook process and defines a small `run()` helper for shell commands.
+
+The Marketplace values below correspond to the public `zembed-1` listing: extension type `zeroentropy.zembedextension`, offer `zeroentropy-zembed-1`, and plan `embedding-monthly-plan`. Set `AZURE_SUBSCRIPTION` explicitly so quota checks and cluster creation run against the same subscription.
+
+
+
+```python
+import os
+import subprocess
+
+config = {
+    "AZURE_SUBSCRIPTION": "<your-subscription-name-or-id>",
+    "AZURE_RESOURCE_GROUP": "<your-resource-group>",
+    "AKS_CLUSTER_NAME": "<your-cluster-name>",
+    "AZURE_LOCATION": "WestUS3",
+    "AKS_NODE_SIZE": "Standard_NC40ads_H100_v5",
+    "AKS_NODE_COUNT": "1",
+    "AKS_ZONE": "1",
+    "AKS_NODE_OSDISK_TYPE": "Managed",
+    "AKS_NODE_OSDISK_SIZE_GB": "512",
+    "AKS_NETWORK_PLUGIN": "kubenet",
+    "ZEMBED_EXTENSION_NAME": "<your-extension-name>",
+    "ZEMBED_EXTENSION_TYPE": "zeroentropy.zembedextension",
+    "ZEMBED_PLAN_NAME": "embedding-monthly-plan",
+    "ZEMBED_PLAN_PRODUCT": "zeroentropy-zembed-1",
+    "ZEMBED_PLAN_PUBLISHER": "zeroentropy",
+    "ZEMBED_NAMESPACE": "zembed-1",
+    "LOCAL_PORT": "8080",
+}
+
+for key, value in config.items():
+    os.environ[key] = value
+
+def run(command: str):
+    return subprocess.run(
+        ["bash", "-e", "-u", "-o", "pipefail", "-c", command],
+        check=True,
+        text=True,
+    )
+
+missing = [key for key, value in config.items() if value.startswith("<") and value.endswith(">")]
+if missing:
+    print("Update these values before running the deployment cells:")
+    for key in missing:
+        print(f"  - {key}")
+else:
+    print("Configuration loaded.")
+
+```
+
+## 2. Check Marketplace terms and quota
+
+Confirm that the Marketplace terms are accepted for the subscription. If `accepted` is `false`, run the following opt-in cell after reviewing the terms in Azure Marketplace.
+
+
+
+```python
+run("""\
+az term show \
+  --subscription "$AZURE_SUBSCRIPTION" \
+  --publisher "$ZEMBED_PLAN_PUBLISHER" \
+  --product "$ZEMBED_PLAN_PRODUCT" \
+  --plan "$ZEMBED_PLAN_NAME" \
+  --query '{accepted:accepted,publisher:publisher,product:product,plan:plan}' \
+  -o json
+""")
+
+```
+
+If the previous cell prints `"accepted": false`, set `accept_marketplace_terms = True` and run this cell. Leave it as `False` if the terms are already accepted or you are not ready to accept them.
+
+
+```python
+accept_marketplace_terms = False
+
+if accept_marketplace_terms:
+    run("""\
+    az term accept \
+      --subscription "$AZURE_SUBSCRIPTION" \
+      --publisher "$ZEMBED_PLAN_PUBLISHER" \
+      --product "$ZEMBED_PLAN_PRODUCT" \
+      --plan "$ZEMBED_PLAN_NAME" \
+      -o json
+    """)
+else:
+    print("Marketplace term acceptance skipped.")
+
+```
+
+Check that the target region has both regional vCPU quota and `Standard NCadsH100v5 Family vCPUs` quota. One `Standard_NC40ads_H100_v5` node requires 40 vCPUs.
+
+
+```python
+run("""\
+echo "SKU availability:"
+az vm list-skus \
+  --subscription "$AZURE_SUBSCRIPTION" \
+  --location "$AZURE_LOCATION" \
+  --size "$AKS_NODE_SIZE" \
+  --all \
+  --query "[?name=='$AKS_NODE_SIZE'].{name:name,locations:locations,restrictions:restrictions[].reasonCode}" \
+  -o json
+
+echo "Quota usage:"
+az vm list-usage \
+  --subscription "$AZURE_SUBSCRIPTION" \
+  --location "$AZURE_LOCATION" \
+  --query "[?name.value=='cores' || contains(name.localizedValue, 'H100')].{name:name.localizedValue,value:name.value,limit:limit,current:currentValue}" \
+  -o table
+""")
+
+```
+
+## 3. Create the AKS cluster
+
+Create a single-node AKS cluster backed by `Standard_NC40ads_H100_v5`. If you already have a suitable cluster, skip this cell and run the `az aks get-credentials` cell below.
+
+The cluster location must have quota for both total regional vCPUs and `Standard NCadsH100v5 Family vCPUs`. The command pins one availability zone and uses managed OS disks plus `kubenet`; this avoids common H100 allocation failures caused by ephemeral OS disk constraints.
+
+
+
+```python
+run("""\
+az aks create \
+  --subscription "$AZURE_SUBSCRIPTION" \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --name "$AKS_CLUSTER_NAME" \
+  --location "$AZURE_LOCATION" \
+  --node-count "$AKS_NODE_COUNT" \
+  --node-vm-size "$AKS_NODE_SIZE" \
+  --node-osdisk-type "$AKS_NODE_OSDISK_TYPE" \
+  --node-osdisk-size "$AKS_NODE_OSDISK_SIZE_GB" \
+  --network-plugin "$AKS_NETWORK_PLUGIN" \
+  --zones "$AKS_ZONE" \
+  --generate-ssh-keys
+""")
+
+```
+
+Connect `kubectl` to the cluster.
+
+
+```python
+run("""\
+az aks get-credentials \
+  --subscription "$AZURE_SUBSCRIPTION" \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --name "$AKS_CLUSTER_NAME" \
+  --overwrite-existing
+
+kubectl get nodes
+""")
+
+```
+
+## 4. Install the NVIDIA device plugin
+
+The device plugin advertises GPU resources to Kubernetes. After installation, wait about one minute for the allocatable GPU count to appear on the node.
+
+
+
+```python
+run("""\
+kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml
+""")
+
+```
+
+Verify that Kubernetes sees the GPU. The kubelet may need a minute to refresh node allocatable resources after the plugin registers. This cell retries until it sees `"gpu": "1"`.
+
+
+
+```python
+run("""\
+for i in {1..12}; do
+  gpu_count=$(kubectl get nodes -o json | jq -r '.items[0].status.allocatable["nvidia.com/gpu"] // ""')
+  if [ "$gpu_count" = "1" ]; then
+    kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: .status.allocatable["nvidia.com/gpu"]}'
+    exit 0
+  fi
+  echo "Waiting for GPU allocatable resource..."
+  sleep 10
+done
+
+kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: .status.allocatable["nvidia.com/gpu"]}'
+exit 1
+""")
+
+```
+
+## 5. Deploy zembed-1 from Azure Marketplace
+
+You can deploy through the [zembed-1 Azure Marketplace listing](https://marketplace.microsoft.com/en-us/product/zeroentropy.zeroentropy-zembed-1?tab=Overview) or create the Kubernetes extension from the CLI.
+
+The command below uses the Marketplace extension type and plan published for `zembed-1`.
+
+
+
+```python
+run("""\
+az k8s-extension create \
+  --subscription "$AZURE_SUBSCRIPTION" \
+  --name "$ZEMBED_EXTENSION_NAME" \
+  --cluster-name "$AKS_CLUSTER_NAME" \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --cluster-type managedClusters \
+  --extension-type "$ZEMBED_EXTENSION_TYPE" \
+  --scope cluster \
+  --release-train stable \
+  --release-namespace "$ZEMBED_NAMESPACE" \
+  --plan-name "$ZEMBED_PLAN_NAME" \
+  --plan-product "$ZEMBED_PLAN_PRODUCT" \
+  --plan-publisher "$ZEMBED_PLAN_PUBLISHER"
+""")
+
+```
+
+## 6. Verify the deployment
+
+Wait until the pod is ready. The first startup can take several minutes while the image is pulled and the model loads.
+
+
+
+```python
+run("""\
+kubectl wait \
+  --for=condition=ready pod \
+  -n "$ZEMBED_NAMESPACE" \
+  -l app.kubernetes.io/name=zembed-1 \
+  --timeout=900s
+
+kubectl get pods -n "$ZEMBED_NAMESPACE" -o wide
+""")
+
+```
+
+List services in the namespace. The request cells below find the `zembed-1` service by label, so the commands keep working if the service name changes.
+
+
+```python
+run("""\
+kubectl get svc -n "$ZEMBED_NAMESPACE" -o wide
+""")
+
+```
+
+Check recent logs if the pod is not ready.
+
+
+```python
+run("""\
+kubectl logs -n "$ZEMBED_NAMESPACE" -l app.kubernetes.io/name=zembed-1 --tail=100
+""")
+
+```
+
+## 7. Port-forward the service
+
+This starts `kubectl port-forward` from the notebook kernel and discovers the service name automatically.
+
+
+
+```python
+import os
+import subprocess
+import time
+
+namespace = os.environ["ZEMBED_NAMESPACE"]
+local_port = os.environ["LOCAL_PORT"]
+
+service_name = subprocess.check_output(
+    [
+        "kubectl",
+        "get",
+        "svc",
+        "-n",
+        namespace,
+        "-l",
+        "app.kubernetes.io/name=zembed-1",
+        "-o",
+        "jsonpath={.items[0].metadata.name}",
+    ],
+    text=True,
+).strip()
+
+if "zembed1_port_forward" in globals() and zembed1_port_forward.poll() is None:
+    zembed1_port_forward.terminate()
+    zembed1_port_forward.wait(timeout=10)
+
+zembed1_port_forward = subprocess.Popen(
+    [
+        "kubectl",
+        "port-forward",
+        "-n",
+        namespace,
+        f"svc/{service_name}",
+        f"{local_port}:80",
+    ],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+)
+
+time.sleep(3)
+if zembed1_port_forward.poll() is not None:
+    output = zembed1_port_forward.stdout.read() if zembed1_port_forward.stdout else ""
+    raise RuntimeError(f"port-forward exited early:\n{output}")
+
+print(f"Forwarding localhost:{local_port} to service/{service_name}:80")
+
+```
+
+## 8. Test the embedding endpoint
+
+Send a sample document embedding request to `/invocations`. The response contains base64-encoded f16 embeddings, token counts, and request usage metadata.
+
+
+
+```python
+import base64
+import json
+import math
+import os
+import struct
+import urllib.request
+
+
+def post_json(path: str, payload: dict):
+    url = f"http://localhost:{os.environ['LOCAL_PORT']}{path}"
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=120) as response:
+        body = response.read().decode("utf-8")
+    return json.loads(body)
+
+
+def decode_embedding(value):
+    if isinstance(value, str):
+        raw = base64.b64decode(value)
+        return list(struct.unpack(f"<{len(raw) // 2}e", raw))
+    return value
+
+payload = {
+    "embedding_type": "document",
+    "input": [
+        "ZeroEntropy zembed-1 creates dense embeddings for retrieval and semantic search.",
+        "A rain gauge measures precipitation over time.",
+    ],
+    "dimensions": 320,
+}
+
+response = post_json("/invocations", payload)
+embeddings = [decode_embedding(item) for item in response["embeddings"]]
+
+assert len(embeddings) == len(payload["input"])
+assert all(len(vector) == payload["dimensions"] for vector in embeddings)
+assert len(response["num_tokens"]) == len(payload["input"])
+
+print(json.dumps({
+    "embedding_count": len(embeddings),
+    "embedding_dimensions": [len(vector) for vector in embeddings],
+    "num_tokens": response["num_tokens"],
+}, indent=2))
+
+```
+
+Run a query/document similarity check. Use `embedding_type="query"` for the query and `embedding_type="document"` for corpus text.
+
+
+```python
+query = "Which document is about semantic search embeddings?"
+documents = [
+    "zembed-1 maps text to vectors for semantic search and RAG.",
+    "H100 GPUs provide high throughput for model inference.",
+    "Garden soil moisture changes after rainfall.",
+]
+
+query_response = post_json("/invocations", {
+    "embedding_type": "query",
+    "input": [query],
+    "dimensions": 320,
+})
+doc_response = post_json("/invocations", {
+    "embedding_type": "document",
+    "input": documents,
+    "dimensions": 320,
+})
+
+q_vec = decode_embedding(query_response["embeddings"][0])
+d_vecs = [decode_embedding(item) for item in doc_response["embeddings"]]
+
+
+def cosine(left, right):
+    numerator = sum(a * b for a, b in zip(left, right, strict=True))
+    left_norm = math.sqrt(sum(value * value for value in left))
+    right_norm = math.sqrt(sum(value * value for value in right))
+    return numerator / (left_norm * right_norm)
+
+ranked = sorted(
+    enumerate(cosine(q_vec, vector) for vector in d_vecs),
+    key=lambda item: item[1],
+    reverse=True,
+)
+
+print(f"Query: {query}\n")
+for rank, (index, score) in enumerate(ranked, 1):
+    print(f"{rank}. score={score:.4f}  doc={documents[index]}")
+
+assert ranked[0][0] == 0, "Expected the semantic-search document to rank first."
+
+```
+
+## 9. Check service health
+
+The health endpoint returns service status, model configuration, and endpoint type.
+
+
+
+```python
+run("""\
+curl "http://localhost:${LOCAL_PORT}/health"
+""")
+
+```
+
+Stop the port-forward process when you are done testing.
+
+
+```python
+if "zembed1_port_forward" in globals() and zembed1_port_forward.poll() is None:
+    zembed1_port_forward.terminate()
+    zembed1_port_forward.wait(timeout=10)
+    print("Stopped port-forward.")
+else:
+    print("No running port-forward process found.")
+
+```
+
+## Troubleshooting
+
+- If AKS creation fails with quota errors, confirm that `AZURE_SUBSCRIPTION` and `AZURE_LOCATION` have quota for both total regional vCPUs and `Standard NCadsH100v5 Family vCPUs`. One `Standard_NC40ads_H100_v5` node requires 40 vCPUs.
+- If AKS creation fails with `OverconstrainedAllocationRequest`, keep `AKS_NODE_OSDISK_TYPE=Managed`, keep `AKS_NETWORK_PLUGIN=kubenet`, and try another supported `AKS_ZONE` from the SKU availability output.
+- If Marketplace terms are not accepted, review the listing and run the opt-in term acceptance cell.
+- If GPU allocation shows `null`, rerun the GPU verification cell. If it still shows `null`, inspect the NVIDIA device plugin pod in `kube-system`.
+- If the Marketplace extension type fails, list the current ZeroEntropy extension registrations with `az k8s-extension extension-types list-by-cluster --subscription "$AZURE_SUBSCRIPTION" --cluster-name "$AKS_CLUSTER_NAME" --resource-group "$AZURE_RESOURCE_GROUP" --cluster-type managedClusters`.
+- If `kubectl port-forward` fails, rerun the service listing cell and confirm the `zembed-1` service exists.
+- If `/invocations` returns a dimension error, use one of the supported dimensions: `40`, `80`, `160`, `320`, `640`, `1280`, or `2560`.
+- If `/invocations` fails after the pod is ready, inspect `/health` and recent logs. A healthy zembed deployment should report `{"status":"healthy","model":"zembed-1","endpoint":"embed"}`.
+
+Because GPU-backed AKS clusters are expensive, delete unused test clusters from the Azure portal or with `az aks delete` after you finish.

--- a/guides/azure_zembed1/azure_zembed1.ipynb
+++ b/guides/azure_zembed1/azure_zembed1.ipynb
@@ -1,0 +1,641 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Deploy zembed-1 on Azure AKS\n",
+        "\n",
+        "This notebook shows how to deploy `zembed-1` from Azure Marketplace to an Azure Kubernetes Service (AKS) cluster with an H100 GPU node. You will create the cluster, install the NVIDIA device plugin, deploy the Marketplace extension, and test the local embedding endpoint through `kubectl port-forward`.\n",
+        "\n",
+        "## Prerequisites\n",
+        "\n",
+        "- An Azure subscription with quota for `Standard_NC40ads_H100_v5`\n",
+        "- Azure CLI (`az`) installed and authenticated with `az login`\n",
+        "- `kubectl` installed\n",
+        "- `jq` installed for JSON inspection\n",
+        "- Permission to create AKS clusters and Azure Kubernetes extensions\n",
+        "- A resource group in the subscription, or permission to create one\n",
+        "\n",
+        "## What you will do\n",
+        "\n",
+        "- Check the Azure Marketplace terms and H100 quota\n",
+        "- Create a single-node AKS cluster with one H100 GPU\n",
+        "- Install the NVIDIA Kubernetes device plugin\n",
+        "- Deploy `zembed-1` through the Azure Marketplace extension\n",
+        "- Verify the pod, service, GPU allocation, and health endpoint\n",
+        "- Send sample embedding requests to `/invocations`\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 1. Configure deployment values\n",
+        "\n",
+        "Set these values before running the command cells. The Python cell exports them to the notebook process and defines a small `run()` helper for shell commands.\n",
+        "\n",
+        "The Marketplace values below correspond to the public `zembed-1` listing: extension type `zeroentropy.zembedextension`, offer `zeroentropy-zembed-1`, and plan `embedding-monthly-plan`. Set `AZURE_SUBSCRIPTION` explicitly so quota checks and cluster creation run against the same subscription.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import subprocess\n",
+        "\n",
+        "config = {\n",
+        "    \"AZURE_SUBSCRIPTION\": \"<your-subscription-name-or-id>\",\n",
+        "    \"AZURE_RESOURCE_GROUP\": \"<your-resource-group>\",\n",
+        "    \"AKS_CLUSTER_NAME\": \"<your-cluster-name>\",\n",
+        "    \"AZURE_LOCATION\": \"WestUS3\",\n",
+        "    \"AKS_NODE_SIZE\": \"Standard_NC40ads_H100_v5\",\n",
+        "    \"AKS_NODE_COUNT\": \"1\",\n",
+        "    \"AKS_ZONE\": \"1\",\n",
+        "    \"AKS_NODE_OSDISK_TYPE\": \"Managed\",\n",
+        "    \"AKS_NODE_OSDISK_SIZE_GB\": \"512\",\n",
+        "    \"AKS_NETWORK_PLUGIN\": \"kubenet\",\n",
+        "    \"ZEMBED_EXTENSION_NAME\": \"<your-extension-name>\",\n",
+        "    \"ZEMBED_EXTENSION_TYPE\": \"zeroentropy.zembedextension\",\n",
+        "    \"ZEMBED_PLAN_NAME\": \"embedding-monthly-plan\",\n",
+        "    \"ZEMBED_PLAN_PRODUCT\": \"zeroentropy-zembed-1\",\n",
+        "    \"ZEMBED_PLAN_PUBLISHER\": \"zeroentropy\",\n",
+        "    \"ZEMBED_NAMESPACE\": \"zembed-1\",\n",
+        "    \"LOCAL_PORT\": \"8080\",\n",
+        "}\n",
+        "\n",
+        "for key, value in config.items():\n",
+        "    os.environ[key] = value\n",
+        "\n",
+        "def run(command: str):\n",
+        "    return subprocess.run(\n",
+        "        [\"bash\", \"-e\", \"-u\", \"-o\", \"pipefail\", \"-c\", command],\n",
+        "        check=True,\n",
+        "        text=True,\n",
+        "    )\n",
+        "\n",
+        "missing = [key for key, value in config.items() if value.startswith(\"<\") and value.endswith(\">\")]\n",
+        "if missing:\n",
+        "    print(\"Update these values before running the deployment cells:\")\n",
+        "    for key in missing:\n",
+        "        print(f\"  - {key}\")\n",
+        "else:\n",
+        "    print(\"Configuration loaded.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 2. Check Marketplace terms and quota\n",
+        "\n",
+        "Confirm that the Marketplace terms are accepted for the subscription. If `accepted` is `false`, run the following opt-in cell after reviewing the terms in Azure Marketplace.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "run(\"\"\"\\\n",
+        "az term show \\\n",
+        "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+        "  --publisher \"$ZEMBED_PLAN_PUBLISHER\" \\\n",
+        "  --product \"$ZEMBED_PLAN_PRODUCT\" \\\n",
+        "  --plan \"$ZEMBED_PLAN_NAME\" \\\n",
+        "  --query '{accepted:accepted,publisher:publisher,product:product,plan:plan}' \\\n",
+        "  -o json\n",
+        "\"\"\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "If the previous cell prints `\"accepted\": false`, set `accept_marketplace_terms = True` and run this cell. Leave it as `False` if the terms are already accepted or you are not ready to accept them."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "accept_marketplace_terms = False\n",
+        "\n",
+        "if accept_marketplace_terms:\n",
+        "    run(\"\"\"\\\n",
+        "    az term accept \\\n",
+        "      --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+        "      --publisher \"$ZEMBED_PLAN_PUBLISHER\" \\\n",
+        "      --product \"$ZEMBED_PLAN_PRODUCT\" \\\n",
+        "      --plan \"$ZEMBED_PLAN_NAME\" \\\n",
+        "      -o json\n",
+        "    \"\"\")\n",
+        "else:\n",
+        "    print(\"Marketplace term acceptance skipped.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Check that the target region has both regional vCPU quota and `Standard NCadsH100v5 Family vCPUs` quota. One `Standard_NC40ads_H100_v5` node requires 40 vCPUs."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "run(\"\"\"\\\n",
+        "echo \"SKU availability:\"\n",
+        "az vm list-skus \\\n",
+        "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+        "  --location \"$AZURE_LOCATION\" \\\n",
+        "  --size \"$AKS_NODE_SIZE\" \\\n",
+        "  --all \\\n",
+        "  --query \"[?name=='$AKS_NODE_SIZE'].{name:name,locations:locations,restrictions:restrictions[].reasonCode}\" \\\n",
+        "  -o json\n",
+        "\n",
+        "echo \"Quota usage:\"\n",
+        "az vm list-usage \\\n",
+        "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+        "  --location \"$AZURE_LOCATION\" \\\n",
+        "  --query \"[?name.value=='cores' || contains(name.localizedValue, 'H100')].{name:name.localizedValue,value:name.value,limit:limit,current:currentValue}\" \\\n",
+        "  -o table\n",
+        "\"\"\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 3. Create the AKS cluster\n",
+        "\n",
+        "Create a single-node AKS cluster backed by `Standard_NC40ads_H100_v5`. If you already have a suitable cluster, skip this cell and run the `az aks get-credentials` cell below.\n",
+        "\n",
+        "The cluster location must have quota for both total regional vCPUs and `Standard NCadsH100v5 Family vCPUs`. The command pins one availability zone and uses managed OS disks plus `kubenet`; this avoids common H100 allocation failures caused by ephemeral OS disk constraints.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "run(\"\"\"\\\n",
+        "az aks create \\\n",
+        "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+        "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
+        "  --name \"$AKS_CLUSTER_NAME\" \\\n",
+        "  --location \"$AZURE_LOCATION\" \\\n",
+        "  --node-count \"$AKS_NODE_COUNT\" \\\n",
+        "  --node-vm-size \"$AKS_NODE_SIZE\" \\\n",
+        "  --node-osdisk-type \"$AKS_NODE_OSDISK_TYPE\" \\\n",
+        "  --node-osdisk-size \"$AKS_NODE_OSDISK_SIZE_GB\" \\\n",
+        "  --network-plugin \"$AKS_NETWORK_PLUGIN\" \\\n",
+        "  --zones \"$AKS_ZONE\" \\\n",
+        "  --generate-ssh-keys\n",
+        "\"\"\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Connect `kubectl` to the cluster."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "run(\"\"\"\\\n",
+        "az aks get-credentials \\\n",
+        "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+        "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
+        "  --name \"$AKS_CLUSTER_NAME\" \\\n",
+        "  --overwrite-existing\n",
+        "\n",
+        "kubectl get nodes\n",
+        "\"\"\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. Install the NVIDIA device plugin\n",
+        "\n",
+        "The device plugin advertises GPU resources to Kubernetes. After installation, wait about one minute for the allocatable GPU count to appear on the node.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "run(\"\"\"\\\n",
+        "kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml\n",
+        "\"\"\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Verify that Kubernetes sees the GPU. The kubelet may need a minute to refresh node allocatable resources after the plugin registers. This cell retries until it sees `\"gpu\": \"1\"`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "run(\"\"\"\\\n",
+        "for i in {1..12}; do\n",
+        "  gpu_count=$(kubectl get nodes -o json | jq -r '.items[0].status.allocatable[\"nvidia.com/gpu\"] // \"\"')\n",
+        "  if [ \"$gpu_count\" = \"1\" ]; then\n",
+        "    kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: .status.allocatable[\"nvidia.com/gpu\"]}'\n",
+        "    exit 0\n",
+        "  fi\n",
+        "  echo \"Waiting for GPU allocatable resource...\"\n",
+        "  sleep 10\n",
+        "done\n",
+        "\n",
+        "kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: .status.allocatable[\"nvidia.com/gpu\"]}'\n",
+        "exit 1\n",
+        "\"\"\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 5. Deploy zembed-1 from Azure Marketplace\n",
+        "\n",
+        "You can deploy through the [zembed-1 Azure Marketplace listing](https://marketplace.microsoft.com/en-us/product/zeroentropy.zeroentropy-zembed-1?tab=Overview) or create the Kubernetes extension from the CLI.\n",
+        "\n",
+        "The command below uses the Marketplace extension type and plan published for `zembed-1`.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "run(\"\"\"\\\n",
+        "az k8s-extension create \\\n",
+        "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+        "  --name \"$ZEMBED_EXTENSION_NAME\" \\\n",
+        "  --cluster-name \"$AKS_CLUSTER_NAME\" \\\n",
+        "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
+        "  --cluster-type managedClusters \\\n",
+        "  --extension-type \"$ZEMBED_EXTENSION_TYPE\" \\\n",
+        "  --scope cluster \\\n",
+        "  --release-train stable \\\n",
+        "  --release-namespace \"$ZEMBED_NAMESPACE\" \\\n",
+        "  --plan-name \"$ZEMBED_PLAN_NAME\" \\\n",
+        "  --plan-product \"$ZEMBED_PLAN_PRODUCT\" \\\n",
+        "  --plan-publisher \"$ZEMBED_PLAN_PUBLISHER\"\n",
+        "\"\"\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 6. Verify the deployment\n",
+        "\n",
+        "Wait until the pod is ready. The first startup can take several minutes while the image is pulled and the model loads.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "run(\"\"\"\\\n",
+        "kubectl wait \\\n",
+        "  --for=condition=ready pod \\\n",
+        "  -n \"$ZEMBED_NAMESPACE\" \\\n",
+        "  -l app.kubernetes.io/name=zembed-1 \\\n",
+        "  --timeout=900s\n",
+        "\n",
+        "kubectl get pods -n \"$ZEMBED_NAMESPACE\" -o wide\n",
+        "\"\"\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "List services in the namespace. The request cells below find the `zembed-1` service by label, so the commands keep working if the service name changes."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "run(\"\"\"\\\n",
+        "kubectl get svc -n \"$ZEMBED_NAMESPACE\" -o wide\n",
+        "\"\"\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Check recent logs if the pod is not ready."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "run(\"\"\"\\\n",
+        "kubectl logs -n \"$ZEMBED_NAMESPACE\" -l app.kubernetes.io/name=zembed-1 --tail=100\n",
+        "\"\"\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 7. Port-forward the service\n",
+        "\n",
+        "This starts `kubectl port-forward` from the notebook kernel and discovers the service name automatically.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import os\n",
+        "import subprocess\n",
+        "import time\n",
+        "\n",
+        "namespace = os.environ[\"ZEMBED_NAMESPACE\"]\n",
+        "local_port = os.environ[\"LOCAL_PORT\"]\n",
+        "\n",
+        "service_name = subprocess.check_output(\n",
+        "    [\n",
+        "        \"kubectl\",\n",
+        "        \"get\",\n",
+        "        \"svc\",\n",
+        "        \"-n\",\n",
+        "        namespace,\n",
+        "        \"-l\",\n",
+        "        \"app.kubernetes.io/name=zembed-1\",\n",
+        "        \"-o\",\n",
+        "        \"jsonpath={.items[0].metadata.name}\",\n",
+        "    ],\n",
+        "    text=True,\n",
+        ").strip()\n",
+        "\n",
+        "if \"zembed1_port_forward\" in globals() and zembed1_port_forward.poll() is None:\n",
+        "    zembed1_port_forward.terminate()\n",
+        "    zembed1_port_forward.wait(timeout=10)\n",
+        "\n",
+        "zembed1_port_forward = subprocess.Popen(\n",
+        "    [\n",
+        "        \"kubectl\",\n",
+        "        \"port-forward\",\n",
+        "        \"-n\",\n",
+        "        namespace,\n",
+        "        f\"svc/{service_name}\",\n",
+        "        f\"{local_port}:80\",\n",
+        "    ],\n",
+        "    stdout=subprocess.PIPE,\n",
+        "    stderr=subprocess.STDOUT,\n",
+        "    text=True,\n",
+        ")\n",
+        "\n",
+        "time.sleep(3)\n",
+        "if zembed1_port_forward.poll() is not None:\n",
+        "    output = zembed1_port_forward.stdout.read() if zembed1_port_forward.stdout else \"\"\n",
+        "    raise RuntimeError(f\"port-forward exited early:\\n{output}\")\n",
+        "\n",
+        "print(f\"Forwarding localhost:{local_port} to service/{service_name}:80\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 8. Test the embedding endpoint\n",
+        "\n",
+        "Send a sample document embedding request to `/invocations`. The response contains base64-encoded f16 embeddings, token counts, and request usage metadata.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import base64\n",
+        "import json\n",
+        "import math\n",
+        "import os\n",
+        "import struct\n",
+        "import urllib.request\n",
+        "\n",
+        "\n",
+        "def post_json(path: str, payload: dict):\n",
+        "    url = f\"http://localhost:{os.environ['LOCAL_PORT']}{path}\"\n",
+        "    data = json.dumps(payload).encode(\"utf-8\")\n",
+        "    request = urllib.request.Request(\n",
+        "        url,\n",
+        "        data=data,\n",
+        "        headers={\"Content-Type\": \"application/json\"},\n",
+        "        method=\"POST\",\n",
+        "    )\n",
+        "    with urllib.request.urlopen(request, timeout=120) as response:\n",
+        "        body = response.read().decode(\"utf-8\")\n",
+        "    return json.loads(body)\n",
+        "\n",
+        "\n",
+        "def decode_embedding(value):\n",
+        "    if isinstance(value, str):\n",
+        "        raw = base64.b64decode(value)\n",
+        "        return list(struct.unpack(f\"<{len(raw) // 2}e\", raw))\n",
+        "    return value\n",
+        "\n",
+        "payload = {\n",
+        "    \"embedding_type\": \"document\",\n",
+        "    \"input\": [\n",
+        "        \"ZeroEntropy zembed-1 creates dense embeddings for retrieval and semantic search.\",\n",
+        "        \"A rain gauge measures precipitation over time.\",\n",
+        "    ],\n",
+        "    \"dimensions\": 320,\n",
+        "}\n",
+        "\n",
+        "response = post_json(\"/invocations\", payload)\n",
+        "embeddings = [decode_embedding(item) for item in response[\"embeddings\"]]\n",
+        "\n",
+        "assert len(embeddings) == len(payload[\"input\"])\n",
+        "assert all(len(vector) == payload[\"dimensions\"] for vector in embeddings)\n",
+        "assert len(response[\"num_tokens\"]) == len(payload[\"input\"])\n",
+        "\n",
+        "print(json.dumps({\n",
+        "    \"embedding_count\": len(embeddings),\n",
+        "    \"embedding_dimensions\": [len(vector) for vector in embeddings],\n",
+        "    \"num_tokens\": response[\"num_tokens\"],\n",
+        "}, indent=2))\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Run a query/document similarity check. Use `embedding_type=\"query\"` for the query and `embedding_type=\"document\"` for corpus text."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "query = \"Which document is about semantic search embeddings?\"\n",
+        "documents = [\n",
+        "    \"zembed-1 maps text to vectors for semantic search and RAG.\",\n",
+        "    \"H100 GPUs provide high throughput for model inference.\",\n",
+        "    \"Garden soil moisture changes after rainfall.\",\n",
+        "]\n",
+        "\n",
+        "query_response = post_json(\"/invocations\", {\n",
+        "    \"embedding_type\": \"query\",\n",
+        "    \"input\": [query],\n",
+        "    \"dimensions\": 320,\n",
+        "})\n",
+        "doc_response = post_json(\"/invocations\", {\n",
+        "    \"embedding_type\": \"document\",\n",
+        "    \"input\": documents,\n",
+        "    \"dimensions\": 320,\n",
+        "})\n",
+        "\n",
+        "q_vec = decode_embedding(query_response[\"embeddings\"][0])\n",
+        "d_vecs = [decode_embedding(item) for item in doc_response[\"embeddings\"]]\n",
+        "\n",
+        "\n",
+        "def cosine(left, right):\n",
+        "    numerator = sum(a * b for a, b in zip(left, right, strict=True))\n",
+        "    left_norm = math.sqrt(sum(value * value for value in left))\n",
+        "    right_norm = math.sqrt(sum(value * value for value in right))\n",
+        "    return numerator / (left_norm * right_norm)\n",
+        "\n",
+        "ranked = sorted(\n",
+        "    enumerate(cosine(q_vec, vector) for vector in d_vecs),\n",
+        "    key=lambda item: item[1],\n",
+        "    reverse=True,\n",
+        ")\n",
+        "\n",
+        "print(f\"Query: {query}\\n\")\n",
+        "for rank, (index, score) in enumerate(ranked, 1):\n",
+        "    print(f\"{rank}. score={score:.4f}  doc={documents[index]}\")\n",
+        "\n",
+        "assert ranked[0][0] == 0, \"Expected the semantic-search document to rank first.\"\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 9. Check service health\n",
+        "\n",
+        "The health endpoint returns service status, model configuration, and endpoint type.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "run(\"\"\"\\\n",
+        "curl \"http://localhost:${LOCAL_PORT}/health\"\n",
+        "\"\"\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Stop the port-forward process when you are done testing."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "if \"zembed1_port_forward\" in globals() and zembed1_port_forward.poll() is None:\n",
+        "    zembed1_port_forward.terminate()\n",
+        "    zembed1_port_forward.wait(timeout=10)\n",
+        "    print(\"Stopped port-forward.\")\n",
+        "else:\n",
+        "    print(\"No running port-forward process found.\")\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Troubleshooting\n",
+        "\n",
+        "- If AKS creation fails with quota errors, confirm that `AZURE_SUBSCRIPTION` and `AZURE_LOCATION` have quota for both total regional vCPUs and `Standard NCadsH100v5 Family vCPUs`. One `Standard_NC40ads_H100_v5` node requires 40 vCPUs.\n",
+        "- If AKS creation fails with `OverconstrainedAllocationRequest`, keep `AKS_NODE_OSDISK_TYPE=Managed`, keep `AKS_NETWORK_PLUGIN=kubenet`, and try another supported `AKS_ZONE` from the SKU availability output.\n",
+        "- If Marketplace terms are not accepted, review the listing and run the opt-in term acceptance cell.\n",
+        "- If GPU allocation shows `null`, rerun the GPU verification cell. If it still shows `null`, inspect the NVIDIA device plugin pod in `kube-system`.\n",
+        "- If the Marketplace extension type fails, list the current ZeroEntropy extension registrations with `az k8s-extension extension-types list-by-cluster --subscription \"$AZURE_SUBSCRIPTION\" --cluster-name \"$AKS_CLUSTER_NAME\" --resource-group \"$AZURE_RESOURCE_GROUP\" --cluster-type managedClusters`.\n",
+        "- If `kubectl port-forward` fails, rerun the service listing cell and confirm the `zembed-1` service exists.\n",
+        "- If `/invocations` returns a dimension error, use one of the supported dimensions: `40`, `80`, `160`, `320`, `640`, `1280`, or `2560`.\n",
+        "- If `/invocations` fails after the pod is ready, inspect `/health` and recent logs. A healthy zembed deployment should report `{\"status\":\"healthy\",\"model\":\"zembed-1\",\"endpoint\":\"embed\"}`.\n",
+        "\n",
+        "Because GPU-backed AKS clusters are expensive, delete unused test clusters from the Azure portal or with `az aks delete` after you finish.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.12"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/guides/azure_zembed1/azure_zembed1.ipynb
+++ b/guides/azure_zembed1/azure_zembed1.ipynb
@@ -1,641 +1,677 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Deploy zembed-1 on Azure AKS\n",
-        "\n",
-        "This notebook shows how to deploy `zembed-1` from Azure Marketplace to an Azure Kubernetes Service (AKS) cluster with an H100 GPU node. You will create the cluster, install the NVIDIA device plugin, deploy the Marketplace extension, and test the local embedding endpoint through `kubectl port-forward`.\n",
-        "\n",
-        "## Prerequisites\n",
-        "\n",
-        "- An Azure subscription with quota for `Standard_NC40ads_H100_v5`\n",
-        "- Azure CLI (`az`) installed and authenticated with `az login`\n",
-        "- `kubectl` installed\n",
-        "- `jq` installed for JSON inspection\n",
-        "- Permission to create AKS clusters and Azure Kubernetes extensions\n",
-        "- A resource group in the subscription, or permission to create one\n",
-        "\n",
-        "## What you will do\n",
-        "\n",
-        "- Check the Azure Marketplace terms and H100 quota\n",
-        "- Create a single-node AKS cluster with one H100 GPU\n",
-        "- Install the NVIDIA Kubernetes device plugin\n",
-        "- Deploy `zembed-1` through the Azure Marketplace extension\n",
-        "- Verify the pod, service, GPU allocation, and health endpoint\n",
-        "- Send sample embedding requests to `/invocations`\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 1. Configure deployment values\n",
-        "\n",
-        "Set these values before running the command cells. The Python cell exports them to the notebook process and defines a small `run()` helper for shell commands.\n",
-        "\n",
-        "The Marketplace values below correspond to the public `zembed-1` listing: extension type `zeroentropy.zembedextension`, offer `zeroentropy-zembed-1`, and plan `embedding-monthly-plan`. Set `AZURE_SUBSCRIPTION` explicitly so quota checks and cluster creation run against the same subscription.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "import subprocess\n",
-        "\n",
-        "config = {\n",
-        "    \"AZURE_SUBSCRIPTION\": \"<your-subscription-name-or-id>\",\n",
-        "    \"AZURE_RESOURCE_GROUP\": \"<your-resource-group>\",\n",
-        "    \"AKS_CLUSTER_NAME\": \"<your-cluster-name>\",\n",
-        "    \"AZURE_LOCATION\": \"WestUS3\",\n",
-        "    \"AKS_NODE_SIZE\": \"Standard_NC40ads_H100_v5\",\n",
-        "    \"AKS_NODE_COUNT\": \"1\",\n",
-        "    \"AKS_ZONE\": \"1\",\n",
-        "    \"AKS_NODE_OSDISK_TYPE\": \"Managed\",\n",
-        "    \"AKS_NODE_OSDISK_SIZE_GB\": \"512\",\n",
-        "    \"AKS_NETWORK_PLUGIN\": \"kubenet\",\n",
-        "    \"ZEMBED_EXTENSION_NAME\": \"<your-extension-name>\",\n",
-        "    \"ZEMBED_EXTENSION_TYPE\": \"zeroentropy.zembedextension\",\n",
-        "    \"ZEMBED_PLAN_NAME\": \"embedding-monthly-plan\",\n",
-        "    \"ZEMBED_PLAN_PRODUCT\": \"zeroentropy-zembed-1\",\n",
-        "    \"ZEMBED_PLAN_PUBLISHER\": \"zeroentropy\",\n",
-        "    \"ZEMBED_NAMESPACE\": \"zembed-1\",\n",
-        "    \"LOCAL_PORT\": \"8080\",\n",
-        "}\n",
-        "\n",
-        "for key, value in config.items():\n",
-        "    os.environ[key] = value\n",
-        "\n",
-        "def run(command: str):\n",
-        "    return subprocess.run(\n",
-        "        [\"bash\", \"-e\", \"-u\", \"-o\", \"pipefail\", \"-c\", command],\n",
-        "        check=True,\n",
-        "        text=True,\n",
-        "    )\n",
-        "\n",
-        "missing = [key for key, value in config.items() if value.startswith(\"<\") and value.endswith(\">\")]\n",
-        "if missing:\n",
-        "    print(\"Update these values before running the deployment cells:\")\n",
-        "    for key in missing:\n",
-        "        print(f\"  - {key}\")\n",
-        "else:\n",
-        "    print(\"Configuration loaded.\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 2. Check Marketplace terms and quota\n",
-        "\n",
-        "Confirm that the Marketplace terms are accepted for the subscription. If `accepted` is `false`, run the following opt-in cell after reviewing the terms in Azure Marketplace.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run(\"\"\"\\\n",
-        "az term show \\\n",
-        "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
-        "  --publisher \"$ZEMBED_PLAN_PUBLISHER\" \\\n",
-        "  --product \"$ZEMBED_PLAN_PRODUCT\" \\\n",
-        "  --plan \"$ZEMBED_PLAN_NAME\" \\\n",
-        "  --query '{accepted:accepted,publisher:publisher,product:product,plan:plan}' \\\n",
-        "  -o json\n",
-        "\"\"\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "If the previous cell prints `\"accepted\": false`, set `accept_marketplace_terms = True` and run this cell. Leave it as `False` if the terms are already accepted or you are not ready to accept them."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "accept_marketplace_terms = False\n",
-        "\n",
-        "if accept_marketplace_terms:\n",
-        "    run(\"\"\"\\\n",
-        "    az term accept \\\n",
-        "      --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
-        "      --publisher \"$ZEMBED_PLAN_PUBLISHER\" \\\n",
-        "      --product \"$ZEMBED_PLAN_PRODUCT\" \\\n",
-        "      --plan \"$ZEMBED_PLAN_NAME\" \\\n",
-        "      -o json\n",
-        "    \"\"\")\n",
-        "else:\n",
-        "    print(\"Marketplace term acceptance skipped.\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Check that the target region has both regional vCPU quota and `Standard NCadsH100v5 Family vCPUs` quota. One `Standard_NC40ads_H100_v5` node requires 40 vCPUs."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run(\"\"\"\\\n",
-        "echo \"SKU availability:\"\n",
-        "az vm list-skus \\\n",
-        "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
-        "  --location \"$AZURE_LOCATION\" \\\n",
-        "  --size \"$AKS_NODE_SIZE\" \\\n",
-        "  --all \\\n",
-        "  --query \"[?name=='$AKS_NODE_SIZE'].{name:name,locations:locations,restrictions:restrictions[].reasonCode}\" \\\n",
-        "  -o json\n",
-        "\n",
-        "echo \"Quota usage:\"\n",
-        "az vm list-usage \\\n",
-        "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
-        "  --location \"$AZURE_LOCATION\" \\\n",
-        "  --query \"[?name.value=='cores' || contains(name.localizedValue, 'H100')].{name:name.localizedValue,value:name.value,limit:limit,current:currentValue}\" \\\n",
-        "  -o table\n",
-        "\"\"\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 3. Create the AKS cluster\n",
-        "\n",
-        "Create a single-node AKS cluster backed by `Standard_NC40ads_H100_v5`. If you already have a suitable cluster, skip this cell and run the `az aks get-credentials` cell below.\n",
-        "\n",
-        "The cluster location must have quota for both total regional vCPUs and `Standard NCadsH100v5 Family vCPUs`. The command pins one availability zone and uses managed OS disks plus `kubenet`; this avoids common H100 allocation failures caused by ephemeral OS disk constraints.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run(\"\"\"\\\n",
-        "az aks create \\\n",
-        "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
-        "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
-        "  --name \"$AKS_CLUSTER_NAME\" \\\n",
-        "  --location \"$AZURE_LOCATION\" \\\n",
-        "  --node-count \"$AKS_NODE_COUNT\" \\\n",
-        "  --node-vm-size \"$AKS_NODE_SIZE\" \\\n",
-        "  --node-osdisk-type \"$AKS_NODE_OSDISK_TYPE\" \\\n",
-        "  --node-osdisk-size \"$AKS_NODE_OSDISK_SIZE_GB\" \\\n",
-        "  --network-plugin \"$AKS_NETWORK_PLUGIN\" \\\n",
-        "  --zones \"$AKS_ZONE\" \\\n",
-        "  --generate-ssh-keys\n",
-        "\"\"\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Connect `kubectl` to the cluster."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run(\"\"\"\\\n",
-        "az aks get-credentials \\\n",
-        "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
-        "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
-        "  --name \"$AKS_CLUSTER_NAME\" \\\n",
-        "  --overwrite-existing\n",
-        "\n",
-        "kubectl get nodes\n",
-        "\"\"\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 4. Install the NVIDIA device plugin\n",
-        "\n",
-        "The device plugin advertises GPU resources to Kubernetes. After installation, wait about one minute for the allocatable GPU count to appear on the node.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run(\"\"\"\\\n",
-        "kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml\n",
-        "\"\"\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Verify that Kubernetes sees the GPU. The kubelet may need a minute to refresh node allocatable resources after the plugin registers. This cell retries until it sees `\"gpu\": \"1\"`.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run(\"\"\"\\\n",
-        "for i in {1..12}; do\n",
-        "  gpu_count=$(kubectl get nodes -o json | jq -r '.items[0].status.allocatable[\"nvidia.com/gpu\"] // \"\"')\n",
-        "  if [ \"$gpu_count\" = \"1\" ]; then\n",
-        "    kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: .status.allocatable[\"nvidia.com/gpu\"]}'\n",
-        "    exit 0\n",
-        "  fi\n",
-        "  echo \"Waiting for GPU allocatable resource...\"\n",
-        "  sleep 10\n",
-        "done\n",
-        "\n",
-        "kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: .status.allocatable[\"nvidia.com/gpu\"]}'\n",
-        "exit 1\n",
-        "\"\"\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 5. Deploy zembed-1 from Azure Marketplace\n",
-        "\n",
-        "You can deploy through the [zembed-1 Azure Marketplace listing](https://marketplace.microsoft.com/en-us/product/zeroentropy.zeroentropy-zembed-1?tab=Overview) or create the Kubernetes extension from the CLI.\n",
-        "\n",
-        "The command below uses the Marketplace extension type and plan published for `zembed-1`.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run(\"\"\"\\\n",
-        "az k8s-extension create \\\n",
-        "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
-        "  --name \"$ZEMBED_EXTENSION_NAME\" \\\n",
-        "  --cluster-name \"$AKS_CLUSTER_NAME\" \\\n",
-        "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
-        "  --cluster-type managedClusters \\\n",
-        "  --extension-type \"$ZEMBED_EXTENSION_TYPE\" \\\n",
-        "  --scope cluster \\\n",
-        "  --release-train stable \\\n",
-        "  --release-namespace \"$ZEMBED_NAMESPACE\" \\\n",
-        "  --plan-name \"$ZEMBED_PLAN_NAME\" \\\n",
-        "  --plan-product \"$ZEMBED_PLAN_PRODUCT\" \\\n",
-        "  --plan-publisher \"$ZEMBED_PLAN_PUBLISHER\"\n",
-        "\"\"\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 6. Verify the deployment\n",
-        "\n",
-        "Wait until the pod is ready. The first startup can take several minutes while the image is pulled and the model loads.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run(\"\"\"\\\n",
-        "kubectl wait \\\n",
-        "  --for=condition=ready pod \\\n",
-        "  -n \"$ZEMBED_NAMESPACE\" \\\n",
-        "  -l app.kubernetes.io/name=zembed-1 \\\n",
-        "  --timeout=900s\n",
-        "\n",
-        "kubectl get pods -n \"$ZEMBED_NAMESPACE\" -o wide\n",
-        "\"\"\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "List services in the namespace. The request cells below find the `zembed-1` service by label, so the commands keep working if the service name changes."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run(\"\"\"\\\n",
-        "kubectl get svc -n \"$ZEMBED_NAMESPACE\" -o wide\n",
-        "\"\"\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Check recent logs if the pod is not ready."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run(\"\"\"\\\n",
-        "kubectl logs -n \"$ZEMBED_NAMESPACE\" -l app.kubernetes.io/name=zembed-1 --tail=100\n",
-        "\"\"\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 7. Port-forward the service\n",
-        "\n",
-        "This starts `kubectl port-forward` from the notebook kernel and discovers the service name automatically.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import os\n",
-        "import subprocess\n",
-        "import time\n",
-        "\n",
-        "namespace = os.environ[\"ZEMBED_NAMESPACE\"]\n",
-        "local_port = os.environ[\"LOCAL_PORT\"]\n",
-        "\n",
-        "service_name = subprocess.check_output(\n",
-        "    [\n",
-        "        \"kubectl\",\n",
-        "        \"get\",\n",
-        "        \"svc\",\n",
-        "        \"-n\",\n",
-        "        namespace,\n",
-        "        \"-l\",\n",
-        "        \"app.kubernetes.io/name=zembed-1\",\n",
-        "        \"-o\",\n",
-        "        \"jsonpath={.items[0].metadata.name}\",\n",
-        "    ],\n",
-        "    text=True,\n",
-        ").strip()\n",
-        "\n",
-        "if \"zembed1_port_forward\" in globals() and zembed1_port_forward.poll() is None:\n",
-        "    zembed1_port_forward.terminate()\n",
-        "    zembed1_port_forward.wait(timeout=10)\n",
-        "\n",
-        "zembed1_port_forward = subprocess.Popen(\n",
-        "    [\n",
-        "        \"kubectl\",\n",
-        "        \"port-forward\",\n",
-        "        \"-n\",\n",
-        "        namespace,\n",
-        "        f\"svc/{service_name}\",\n",
-        "        f\"{local_port}:80\",\n",
-        "    ],\n",
-        "    stdout=subprocess.PIPE,\n",
-        "    stderr=subprocess.STDOUT,\n",
-        "    text=True,\n",
-        ")\n",
-        "\n",
-        "time.sleep(3)\n",
-        "if zembed1_port_forward.poll() is not None:\n",
-        "    output = zembed1_port_forward.stdout.read() if zembed1_port_forward.stdout else \"\"\n",
-        "    raise RuntimeError(f\"port-forward exited early:\\n{output}\")\n",
-        "\n",
-        "print(f\"Forwarding localhost:{local_port} to service/{service_name}:80\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 8. Test the embedding endpoint\n",
-        "\n",
-        "Send a sample document embedding request to `/invocations`. The response contains base64-encoded f16 embeddings, token counts, and request usage metadata.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import base64\n",
-        "import json\n",
-        "import math\n",
-        "import os\n",
-        "import struct\n",
-        "import urllib.request\n",
-        "\n",
-        "\n",
-        "def post_json(path: str, payload: dict):\n",
-        "    url = f\"http://localhost:{os.environ['LOCAL_PORT']}{path}\"\n",
-        "    data = json.dumps(payload).encode(\"utf-8\")\n",
-        "    request = urllib.request.Request(\n",
-        "        url,\n",
-        "        data=data,\n",
-        "        headers={\"Content-Type\": \"application/json\"},\n",
-        "        method=\"POST\",\n",
-        "    )\n",
-        "    with urllib.request.urlopen(request, timeout=120) as response:\n",
-        "        body = response.read().decode(\"utf-8\")\n",
-        "    return json.loads(body)\n",
-        "\n",
-        "\n",
-        "def decode_embedding(value):\n",
-        "    if isinstance(value, str):\n",
-        "        raw = base64.b64decode(value)\n",
-        "        return list(struct.unpack(f\"<{len(raw) // 2}e\", raw))\n",
-        "    return value\n",
-        "\n",
-        "payload = {\n",
-        "    \"embedding_type\": \"document\",\n",
-        "    \"input\": [\n",
-        "        \"ZeroEntropy zembed-1 creates dense embeddings for retrieval and semantic search.\",\n",
-        "        \"A rain gauge measures precipitation over time.\",\n",
-        "    ],\n",
-        "    \"dimensions\": 320,\n",
-        "}\n",
-        "\n",
-        "response = post_json(\"/invocations\", payload)\n",
-        "embeddings = [decode_embedding(item) for item in response[\"embeddings\"]]\n",
-        "\n",
-        "assert len(embeddings) == len(payload[\"input\"])\n",
-        "assert all(len(vector) == payload[\"dimensions\"] for vector in embeddings)\n",
-        "assert len(response[\"num_tokens\"]) == len(payload[\"input\"])\n",
-        "\n",
-        "print(json.dumps({\n",
-        "    \"embedding_count\": len(embeddings),\n",
-        "    \"embedding_dimensions\": [len(vector) for vector in embeddings],\n",
-        "    \"num_tokens\": response[\"num_tokens\"],\n",
-        "}, indent=2))\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Run a query/document similarity check. Use `embedding_type=\"query\"` for the query and `embedding_type=\"document\"` for corpus text."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "query = \"Which document is about semantic search embeddings?\"\n",
-        "documents = [\n",
-        "    \"zembed-1 maps text to vectors for semantic search and RAG.\",\n",
-        "    \"H100 GPUs provide high throughput for model inference.\",\n",
-        "    \"Garden soil moisture changes after rainfall.\",\n",
-        "]\n",
-        "\n",
-        "query_response = post_json(\"/invocations\", {\n",
-        "    \"embedding_type\": \"query\",\n",
-        "    \"input\": [query],\n",
-        "    \"dimensions\": 320,\n",
-        "})\n",
-        "doc_response = post_json(\"/invocations\", {\n",
-        "    \"embedding_type\": \"document\",\n",
-        "    \"input\": documents,\n",
-        "    \"dimensions\": 320,\n",
-        "})\n",
-        "\n",
-        "q_vec = decode_embedding(query_response[\"embeddings\"][0])\n",
-        "d_vecs = [decode_embedding(item) for item in doc_response[\"embeddings\"]]\n",
-        "\n",
-        "\n",
-        "def cosine(left, right):\n",
-        "    numerator = sum(a * b for a, b in zip(left, right, strict=True))\n",
-        "    left_norm = math.sqrt(sum(value * value for value in left))\n",
-        "    right_norm = math.sqrt(sum(value * value for value in right))\n",
-        "    return numerator / (left_norm * right_norm)\n",
-        "\n",
-        "ranked = sorted(\n",
-        "    enumerate(cosine(q_vec, vector) for vector in d_vecs),\n",
-        "    key=lambda item: item[1],\n",
-        "    reverse=True,\n",
-        ")\n",
-        "\n",
-        "print(f\"Query: {query}\\n\")\n",
-        "for rank, (index, score) in enumerate(ranked, 1):\n",
-        "    print(f\"{rank}. score={score:.4f}  doc={documents[index]}\")\n",
-        "\n",
-        "assert ranked[0][0] == 0, \"Expected the semantic-search document to rank first.\"\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## 9. Check service health\n",
-        "\n",
-        "The health endpoint returns service status, model configuration, and endpoint type.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "run(\"\"\"\\\n",
-        "curl \"http://localhost:${LOCAL_PORT}/health\"\n",
-        "\"\"\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Stop the port-forward process when you are done testing."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "if \"zembed1_port_forward\" in globals() and zembed1_port_forward.poll() is None:\n",
-        "    zembed1_port_forward.terminate()\n",
-        "    zembed1_port_forward.wait(timeout=10)\n",
-        "    print(\"Stopped port-forward.\")\n",
-        "else:\n",
-        "    print(\"No running port-forward process found.\")\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Troubleshooting\n",
-        "\n",
-        "- If AKS creation fails with quota errors, confirm that `AZURE_SUBSCRIPTION` and `AZURE_LOCATION` have quota for both total regional vCPUs and `Standard NCadsH100v5 Family vCPUs`. One `Standard_NC40ads_H100_v5` node requires 40 vCPUs.\n",
-        "- If AKS creation fails with `OverconstrainedAllocationRequest`, keep `AKS_NODE_OSDISK_TYPE=Managed`, keep `AKS_NETWORK_PLUGIN=kubenet`, and try another supported `AKS_ZONE` from the SKU availability output.\n",
-        "- If Marketplace terms are not accepted, review the listing and run the opt-in term acceptance cell.\n",
-        "- If GPU allocation shows `null`, rerun the GPU verification cell. If it still shows `null`, inspect the NVIDIA device plugin pod in `kube-system`.\n",
-        "- If the Marketplace extension type fails, list the current ZeroEntropy extension registrations with `az k8s-extension extension-types list-by-cluster --subscription \"$AZURE_SUBSCRIPTION\" --cluster-name \"$AKS_CLUSTER_NAME\" --resource-group \"$AZURE_RESOURCE_GROUP\" --cluster-type managedClusters`.\n",
-        "- If `kubectl port-forward` fails, rerun the service listing cell and confirm the `zembed-1` service exists.\n",
-        "- If `/invocations` returns a dimension error, use one of the supported dimensions: `40`, `80`, `160`, `320`, `640`, `1280`, or `2560`.\n",
-        "- If `/invocations` fails after the pod is ready, inspect `/health` and recent logs. A healthy zembed deployment should report `{\"status\":\"healthy\",\"model\":\"zembed-1\",\"endpoint\":\"embed\"}`.\n",
-        "\n",
-        "Because GPU-backed AKS clusters are expensive, delete unused test clusters from the Azure portal or with `az aks delete` after you finish.\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.12"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "27c0a0b0",
+   "metadata": {},
+   "source": [
+    "# Deploy zembed-1 on Azure AKS\n",
+    "\n",
+    "This notebook shows how to deploy `zembed-1` from Azure Marketplace to an Azure Kubernetes Service (AKS) cluster with an H100 GPU node. You will create the cluster, install the NVIDIA device plugin, deploy the Marketplace extension, and test the local embedding endpoint through `kubectl port-forward`.\n",
+    "\n",
+    "## Prerequisites\n",
+    "\n",
+    "- An Azure subscription with quota for `Standard_NC40ads_H100_v5`\n",
+    "- Azure CLI (`az`) installed and authenticated with `az login`\n",
+    "- `kubectl` installed\n",
+    "- `jq` installed for JSON inspection\n",
+    "- Permission to create AKS clusters and Azure Kubernetes extensions\n",
+    "- A resource group in the subscription, or permission to create one\n",
+    "\n",
+    "## What you will do\n",
+    "\n",
+    "- Check the Azure Marketplace terms and H100 quota\n",
+    "- Create a single-node AKS cluster with one H100 GPU\n",
+    "- Install the NVIDIA Kubernetes device plugin\n",
+    "- Deploy `zembed-1` through the Azure Marketplace extension\n",
+    "- Verify the pod, service, GPU allocation, and health endpoint\n",
+    "- Send sample embedding requests to `/invocations`\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "markdown",
+   "id": "eb3884c6",
+   "metadata": {},
+   "source": [
+    "## 1. Configure deployment values\n",
+    "\n",
+    "Set these values before running the command cells. The Python cell exports them to the notebook process and defines a small `run()` helper for shell commands.\n",
+    "\n",
+    "The Marketplace values below correspond to the public `zembed-1` listing: extension type `zeroentropy.zembedextension`, offer `zeroentropy-zembed-1`, and plan `embedding-monthly-plan`. Set `AZURE_SUBSCRIPTION` explicitly so quota checks and cluster creation run against the same subscription.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6731322",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import subprocess\n",
+    "\n",
+    "config = {\n",
+    "    \"AZURE_SUBSCRIPTION\": \"<your-subscription-name-or-id>\",\n",
+    "    \"AZURE_RESOURCE_GROUP\": \"<your-resource-group>\",\n",
+    "    \"AKS_CLUSTER_NAME\": \"<your-cluster-name>\",\n",
+    "    \"AZURE_LOCATION\": \"WestUS3\",\n",
+    "    \"AKS_NODE_SIZE\": \"Standard_NC40ads_H100_v5\",\n",
+    "    \"AKS_NODE_COUNT\": \"1\",\n",
+    "    \"AKS_ZONE\": \"1\",\n",
+    "    \"AKS_NODE_OSDISK_TYPE\": \"Managed\",\n",
+    "    \"AKS_NODE_OSDISK_SIZE_GB\": \"512\",\n",
+    "    \"AKS_NETWORK_PLUGIN\": \"kubenet\",\n",
+    "    \"ZEMBED_EXTENSION_NAME\": \"<your-extension-name>\",\n",
+    "    \"ZEMBED_EXTENSION_TYPE\": \"zeroentropy.zembedextension\",\n",
+    "    \"ZEMBED_PLAN_NAME\": \"embedding-monthly-plan\",\n",
+    "    \"ZEMBED_PLAN_PRODUCT\": \"zeroentropy-zembed-1\",\n",
+    "    \"ZEMBED_PLAN_PUBLISHER\": \"zeroentropy\",\n",
+    "    \"ZEMBED_NAMESPACE\": \"zembed-1\",\n",
+    "    \"LOCAL_PORT\": \"8080\",\n",
+    "}\n",
+    "\n",
+    "for key, value in config.items():\n",
+    "    os.environ[key] = value\n",
+    "\n",
+    "def run(command: str):\n",
+    "    return subprocess.run(\n",
+    "        [\"bash\", \"-e\", \"-u\", \"-o\", \"pipefail\", \"-c\", command],\n",
+    "        check=True,\n",
+    "        text=True,\n",
+    "    )\n",
+    "\n",
+    "missing = [key for key, value in config.items() if value.startswith(\"<\") and value.endswith(\">\")]\n",
+    "if missing:\n",
+    "    print(\"Update these values before running the deployment cells:\")\n",
+    "    for key in missing:\n",
+    "        print(f\"  - {key}\")\n",
+    "else:\n",
+    "    print(\"Configuration loaded.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f45494fb",
+   "metadata": {},
+   "source": [
+    "## 2. Check Marketplace terms and quota\n",
+    "\n",
+    "Confirm that the Marketplace terms are accepted for the subscription. If `accepted` is `false`, run the following opt-in cell after reviewing the terms in Azure Marketplace.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "276fa37a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(\"\"\"\\\n",
+    "az term show \\\n",
+    "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+    "  --publisher \"$ZEMBED_PLAN_PUBLISHER\" \\\n",
+    "  --product \"$ZEMBED_PLAN_PRODUCT\" \\\n",
+    "  --plan \"$ZEMBED_PLAN_NAME\" \\\n",
+    "  --query '{accepted:accepted,publisher:publisher,product:product,plan:plan}' \\\n",
+    "  -o json\n",
+    "\"\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17c0fe04",
+   "metadata": {},
+   "source": [
+    "If the previous cell prints `\"accepted\": false`, set `accept_marketplace_terms = True` and run this cell. Leave it as `False` if the terms are already accepted or you are not ready to accept them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "981106a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "accept_marketplace_terms = False\n",
+    "\n",
+    "if accept_marketplace_terms:\n",
+    "    run(\"\"\"\\\n",
+    "    az term accept \\\n",
+    "      --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+    "      --publisher \"$ZEMBED_PLAN_PUBLISHER\" \\\n",
+    "      --product \"$ZEMBED_PLAN_PRODUCT\" \\\n",
+    "      --plan \"$ZEMBED_PLAN_NAME\" \\\n",
+    "      -o json\n",
+    "    \"\"\")\n",
+    "else:\n",
+    "    print(\"Marketplace term acceptance skipped.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb3f4bcb",
+   "metadata": {},
+   "source": [
+    "Check that the target region has both regional vCPU quota and `Standard NCadsH100v5 Family vCPUs` quota. One `Standard_NC40ads_H100_v5` node requires 40 vCPUs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4128ecd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(\"\"\"\\\n",
+    "echo \"SKU availability:\"\n",
+    "az vm list-skus \\\n",
+    "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+    "  --location \"$AZURE_LOCATION\" \\\n",
+    "  --size \"$AKS_NODE_SIZE\" \\\n",
+    "  --all \\\n",
+    "  --query \"[?name=='$AKS_NODE_SIZE'].{name:name,locations:locations,restrictions:restrictions[].reasonCode}\" \\\n",
+    "  -o json\n",
+    "\n",
+    "echo \"Quota usage:\"\n",
+    "az vm list-usage \\\n",
+    "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+    "  --location \"$AZURE_LOCATION\" \\\n",
+    "  --query \"[?name.value=='cores' || contains(name.localizedValue, 'H100')].{name:name.localizedValue,value:name.value,limit:limit,current:currentValue}\" \\\n",
+    "  -o table\n",
+    "\"\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1569b404",
+   "metadata": {},
+   "source": [
+    "## 3. Create the AKS cluster\n",
+    "\n",
+    "Create a single-node AKS cluster backed by `Standard_NC40ads_H100_v5`. If you already have a suitable cluster, skip this cell and run the `az aks get-credentials` cell below.\n",
+    "\n",
+    "The cluster location must have quota for both total regional vCPUs and `Standard NCadsH100v5 Family vCPUs`. The command pins one availability zone and uses managed OS disks plus `kubenet`; this avoids common H100 allocation failures caused by ephemeral OS disk constraints.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b81b49f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(\"\"\"\\\n",
+    "az aks create \\\n",
+    "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+    "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
+    "  --name \"$AKS_CLUSTER_NAME\" \\\n",
+    "  --location \"$AZURE_LOCATION\" \\\n",
+    "  --node-count \"$AKS_NODE_COUNT\" \\\n",
+    "  --node-vm-size \"$AKS_NODE_SIZE\" \\\n",
+    "  --node-osdisk-type \"$AKS_NODE_OSDISK_TYPE\" \\\n",
+    "  --node-osdisk-size \"$AKS_NODE_OSDISK_SIZE_GB\" \\\n",
+    "  --network-plugin \"$AKS_NETWORK_PLUGIN\" \\\n",
+    "  --zones \"$AKS_ZONE\" \\\n",
+    "  --generate-ssh-keys\n",
+    "\"\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d8da86a",
+   "metadata": {},
+   "source": [
+    "Connect `kubectl` to the cluster."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9ee6132",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(\"\"\"\\\n",
+    "az aks get-credentials \\\n",
+    "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+    "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
+    "  --name \"$AKS_CLUSTER_NAME\" \\\n",
+    "  --overwrite-existing\n",
+    "\n",
+    "kubectl get nodes\n",
+    "\"\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "89070c3c",
+   "metadata": {},
+   "source": [
+    "## 4. Install the NVIDIA device plugin\n",
+    "\n",
+    "The device plugin advertises GPU resources to Kubernetes. After installation, wait about one minute for the allocatable GPU count to appear on the node.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5cd2d5b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(\"\"\"\\\n",
+    "kubectl apply -f https://raw.githubusercontent.com/NVIDIA/k8s-device-plugin/v0.17.0/deployments/static/nvidia-device-plugin.yml\n",
+    "\"\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07ffd2fb",
+   "metadata": {},
+   "source": [
+    "Verify that Kubernetes sees the GPU. The kubelet may need a minute to refresh node allocatable resources after the plugin registers. This cell retries until it sees `\"gpu\": \"1\"`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6a733f14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(\"\"\"\\\n",
+    "for i in {1..12}; do\n",
+    "  gpu_count=$(kubectl get nodes -o json | jq -r '.items[0].status.allocatable[\"nvidia.com/gpu\"] // \"\"')\n",
+    "  if [ \"$gpu_count\" = \"1\" ]; then\n",
+    "    kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: .status.allocatable[\"nvidia.com/gpu\"]}'\n",
+    "    exit 0\n",
+    "  fi\n",
+    "  echo \"Waiting for GPU allocatable resource...\"\n",
+    "  sleep 10\n",
+    "done\n",
+    "\n",
+    "kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, gpu: .status.allocatable[\"nvidia.com/gpu\"]}'\n",
+    "exit 1\n",
+    "\"\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14102e7c",
+   "metadata": {},
+   "source": [
+    "## 5. Deploy zembed-1 from Azure Marketplace\n",
+    "\n",
+    "You can deploy through the [zembed-1 Azure Marketplace listing](https://marketplace.microsoft.com/en-us/product/zeroentropy.zeroentropy-zembed-1?tab=Overview) or create the Kubernetes extension from the CLI.\n",
+    "\n",
+    "The command below uses the Marketplace extension type and plan published for `zembed-1`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fccf60cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(\"\"\"\\\n",
+    "az k8s-extension create \\\n",
+    "  --subscription \"$AZURE_SUBSCRIPTION\" \\\n",
+    "  --name \"$ZEMBED_EXTENSION_NAME\" \\\n",
+    "  --cluster-name \"$AKS_CLUSTER_NAME\" \\\n",
+    "  --resource-group \"$AZURE_RESOURCE_GROUP\" \\\n",
+    "  --cluster-type managedClusters \\\n",
+    "  --extension-type \"$ZEMBED_EXTENSION_TYPE\" \\\n",
+    "  --scope cluster \\\n",
+    "  --release-train stable \\\n",
+    "  --release-namespace \"$ZEMBED_NAMESPACE\" \\\n",
+    "  --plan-name \"$ZEMBED_PLAN_NAME\" \\\n",
+    "  --plan-product \"$ZEMBED_PLAN_PRODUCT\" \\\n",
+    "  --plan-publisher \"$ZEMBED_PLAN_PUBLISHER\"\n",
+    "\"\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "332c0117",
+   "metadata": {},
+   "source": [
+    "## 6. Verify the deployment\n",
+    "\n",
+    "Wait until the pod is ready. The first startup can take several minutes while the image is pulled and the model loads.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6f61d02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(\"\"\"\\\n",
+    "kubectl wait \\\n",
+    "  --for=condition=ready pod \\\n",
+    "  -n \"$ZEMBED_NAMESPACE\" \\\n",
+    "  -l app.kubernetes.io/name=zembed-1 \\\n",
+    "  --timeout=900s\n",
+    "\n",
+    "kubectl get pods -n \"$ZEMBED_NAMESPACE\" -o wide\n",
+    "\"\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "816f739e",
+   "metadata": {},
+   "source": [
+    "List services in the namespace. The request cells below find the `zembed-1` service by label, so the commands keep working if the service name changes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23ad6181",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(\"\"\"\\\n",
+    "kubectl get svc -n \"$ZEMBED_NAMESPACE\" -o wide\n",
+    "\"\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8f159331",
+   "metadata": {},
+   "source": [
+    "Check recent logs if the pod is not ready."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64f37dc5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(\"\"\"\\\n",
+    "kubectl logs -n \"$ZEMBED_NAMESPACE\" -l app.kubernetes.io/name=zembed-1 --tail=100\n",
+    "\"\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4094701e",
+   "metadata": {},
+   "source": [
+    "## 7. Port-forward the service\n",
+    "\n",
+    "This starts `kubectl port-forward` from the notebook kernel and discovers the service name automatically.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe0d1195",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import subprocess\n",
+    "import time\n",
+    "\n",
+    "namespace = os.environ[\"ZEMBED_NAMESPACE\"]\n",
+    "local_port = os.environ[\"LOCAL_PORT\"]\n",
+    "\n",
+    "service_name = subprocess.check_output(\n",
+    "    [\n",
+    "        \"kubectl\",\n",
+    "        \"get\",\n",
+    "        \"svc\",\n",
+    "        \"-n\",\n",
+    "        namespace,\n",
+    "        \"-l\",\n",
+    "        \"app.kubernetes.io/name=zembed-1\",\n",
+    "        \"-o\",\n",
+    "        \"jsonpath={.items[0].metadata.name}\",\n",
+    "    ],\n",
+    "    text=True,\n",
+    ").strip()\n",
+    "\n",
+    "if \"zembed1_port_forward\" in globals() and zembed1_port_forward.poll() is None:\n",
+    "    zembed1_port_forward.terminate()\n",
+    "    zembed1_port_forward.wait(timeout=10)\n",
+    "\n",
+    "zembed1_port_forward = subprocess.Popen(\n",
+    "    [\n",
+    "        \"kubectl\",\n",
+    "        \"port-forward\",\n",
+    "        \"-n\",\n",
+    "        namespace,\n",
+    "        f\"svc/{service_name}\",\n",
+    "        f\"{local_port}:80\",\n",
+    "    ],\n",
+    "    stdout=subprocess.PIPE,\n",
+    "    stderr=subprocess.STDOUT,\n",
+    "    text=True,\n",
+    ")\n",
+    "\n",
+    "time.sleep(3)\n",
+    "if zembed1_port_forward.poll() is not None:\n",
+    "    output = zembed1_port_forward.stdout.read() if zembed1_port_forward.stdout else \"\"\n",
+    "    raise RuntimeError(f\"port-forward exited early:\\n{output}\")\n",
+    "\n",
+    "print(f\"Forwarding localhost:{local_port} to service/{service_name}:80\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "086ac400",
+   "metadata": {},
+   "source": [
+    "## 8. Test the embedding endpoint\n",
+    "\n",
+    "Send a sample document embedding request to `/invocations`. The response contains base64-encoded f16 embeddings, token counts, and request usage metadata.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2963fb35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import base64\n",
+    "import json\n",
+    "import math\n",
+    "import os\n",
+    "import struct\n",
+    "import urllib.request\n",
+    "\n",
+    "\n",
+    "def post_json(path: str, payload: dict):\n",
+    "    url = f\"http://localhost:{os.environ['LOCAL_PORT']}{path}\"\n",
+    "    data = json.dumps(payload).encode(\"utf-8\")\n",
+    "    request = urllib.request.Request(\n",
+    "        url,\n",
+    "        data=data,\n",
+    "        headers={\"Content-Type\": \"application/json\"},\n",
+    "        method=\"POST\",\n",
+    "    )\n",
+    "    with urllib.request.urlopen(request, timeout=120) as response:\n",
+    "        body = response.read().decode(\"utf-8\")\n",
+    "    return json.loads(body)\n",
+    "\n",
+    "\n",
+    "def decode_embedding(value):\n",
+    "    if isinstance(value, str):\n",
+    "        raw = base64.b64decode(value)\n",
+    "        return list(struct.unpack(f\"<{len(raw) // 2}e\", raw))\n",
+    "    return value\n",
+    "\n",
+    "payload = {\n",
+    "    \"embedding_type\": \"document\",\n",
+    "    \"input\": [\n",
+    "        \"ZeroEntropy zembed-1 creates dense embeddings for retrieval and semantic search.\",\n",
+    "        \"A rain gauge measures precipitation over time.\",\n",
+    "    ],\n",
+    "    \"dimensions\": 320,\n",
+    "}\n",
+    "\n",
+    "response = post_json(\"/invocations\", payload)\n",
+    "embeddings = [decode_embedding(item) for item in response[\"embeddings\"]]\n",
+    "\n",
+    "assert len(embeddings) == len(payload[\"input\"])\n",
+    "assert all(len(vector) == payload[\"dimensions\"] for vector in embeddings)\n",
+    "assert len(response[\"num_tokens\"]) == len(payload[\"input\"])\n",
+    "\n",
+    "print(json.dumps({\n",
+    "    \"embedding_count\": len(embeddings),\n",
+    "    \"embedding_dimensions\": [len(vector) for vector in embeddings],\n",
+    "    \"num_tokens\": response[\"num_tokens\"],\n",
+    "}, indent=2))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0afeaefe",
+   "metadata": {},
+   "source": [
+    "Run a query/document similarity check. Use `embedding_type=\"query\"` for the query and `embedding_type=\"document\"` for corpus text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1db3d199",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"Which document is about semantic search embeddings?\"\n",
+    "documents = [\n",
+    "    \"zembed-1 maps text to vectors for semantic search and RAG.\",\n",
+    "    \"H100 GPUs provide high throughput for model inference.\",\n",
+    "    \"Garden soil moisture changes after rainfall.\",\n",
+    "]\n",
+    "\n",
+    "query_response = post_json(\"/invocations\", {\n",
+    "    \"embedding_type\": \"query\",\n",
+    "    \"input\": [query],\n",
+    "    \"dimensions\": 320,\n",
+    "})\n",
+    "doc_response = post_json(\"/invocations\", {\n",
+    "    \"embedding_type\": \"document\",\n",
+    "    \"input\": documents,\n",
+    "    \"dimensions\": 320,\n",
+    "})\n",
+    "\n",
+    "q_vec = decode_embedding(query_response[\"embeddings\"][0])\n",
+    "d_vecs = [decode_embedding(item) for item in doc_response[\"embeddings\"]]\n",
+    "\n",
+    "\n",
+    "def cosine(left, right):\n",
+    "    numerator = sum(a * b for a, b in zip(left, right, strict=True))\n",
+    "    left_norm = math.sqrt(sum(value * value for value in left))\n",
+    "    right_norm = math.sqrt(sum(value * value for value in right))\n",
+    "    return numerator / (left_norm * right_norm)\n",
+    "\n",
+    "ranked = sorted(\n",
+    "    enumerate(cosine(q_vec, vector) for vector in d_vecs),\n",
+    "    key=lambda item: item[1],\n",
+    "    reverse=True,\n",
+    ")\n",
+    "\n",
+    "print(f\"Query: {query}\\n\")\n",
+    "for rank, (index, score) in enumerate(ranked, 1):\n",
+    "    print(f\"{rank}. score={score:.4f}  doc={documents[index]}\")\n",
+    "\n",
+    "assert ranked[0][0] == 0, \"Expected the semantic-search document to rank first.\"\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0d3c1d89",
+   "metadata": {},
+   "source": [
+    "## 9. Check service health\n",
+    "\n",
+    "The health endpoint returns service status, model configuration, and endpoint type.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c84ad2da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run(\"\"\"\\\n",
+    "curl \"http://localhost:${LOCAL_PORT}/health\"\n",
+    "\"\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1795d8ff",
+   "metadata": {},
+   "source": [
+    "Stop the port-forward process when you are done testing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "178e2836",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if \"zembed1_port_forward\" in globals() and zembed1_port_forward.poll() is None:\n",
+    "    zembed1_port_forward.terminate()\n",
+    "    zembed1_port_forward.wait(timeout=10)\n",
+    "    print(\"Stopped port-forward.\")\n",
+    "else:\n",
+    "    print(\"No running port-forward process found.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cebb0e7a",
+   "metadata": {},
+   "source": [
+    "## Troubleshooting\n",
+    "\n",
+    "- If AKS creation fails with quota errors, confirm that `AZURE_SUBSCRIPTION` and `AZURE_LOCATION` have quota for both total regional vCPUs and `Standard NCadsH100v5 Family vCPUs`. One `Standard_NC40ads_H100_v5` node requires 40 vCPUs.\n",
+    "- If AKS creation fails with `OverconstrainedAllocationRequest`, keep `AKS_NODE_OSDISK_TYPE=Managed`, keep `AKS_NETWORK_PLUGIN=kubenet`, and try another supported `AKS_ZONE` from the SKU availability output.\n",
+    "- If Marketplace terms are not accepted, review the listing and run the opt-in term acceptance cell.\n",
+    "- If GPU allocation shows `null`, rerun the GPU verification cell. If it still shows `null`, inspect the NVIDIA device plugin pod in `kube-system`.\n",
+    "- If the Marketplace extension type fails, list the current ZeroEntropy extension registrations with `az k8s-extension extension-types list-by-cluster --subscription \"$AZURE_SUBSCRIPTION\" --cluster-name \"$AKS_CLUSTER_NAME\" --resource-group \"$AZURE_RESOURCE_GROUP\" --cluster-type managedClusters`.\n",
+    "- If `kubectl port-forward` fails, rerun the service listing cell and confirm the `zembed-1` service exists.\n",
+    "- If `/invocations` returns a dimension error, use one of the supported dimensions: `40`, `80`, `160`, `320`, `640`, `1280`, or `2560`.\n",
+    "- If `/invocations` fails after the pod is ready, inspect `/health` and recent logs. A healthy zembed deployment should report `{\"status\":\"healthy\",\"model\":\"zembed-1\",\"endpoint\":\"embed\"}`.\n",
+    "\n",
+    "Because GPU-backed AKS clusters are expensive, delete unused test clusters from the Azure portal or with `az aks delete` after you finish.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- Add an Azure Marketplace zembed-1 AKS cookbook notebook
- Add a Markdown mirror so the guide renders on GitHub when the notebook iframe renderer fails
- Link the new guide from the cookbook README

## Verification
- Executed the notebook flow end to end against Azure with AKS H100 in westus3
- Confirmed Marketplace extension type zeroentropy.zembedextension and plan embedding-monthly-plan
- Verified pod readiness, /invocations embeddings, semantic ranking assertion, and /health
- Deleted temporary AKS cluster and confirmed H100 quota returned to 0 used
- Rendered the notebook locally with nbformat 5.10.4 / nbconvert 7.17.1
- Opened the Markdown guide on GitHub and confirmed the cookbook content renders
